### PR TITLE
Add profile for Common Crypto Authority

### DIFF
--- a/data/members/ccauth.yaml
+++ b/data/members/ccauth.yaml
@@ -1,0 +1,54 @@
+id: ccauth
+name: Common Crypto Authority
+slogan:
+website: https://www.ccauth.org/
+
+# Short description, longer content can be placed in `content/members/`
+description: I help companies build out technical infrastructure to support ecommerce, real time payments, or in a consultive or proof of concept capacity to build new, or improve the security of existing encryption infrastructure.
+
+# membership
+memberSince: 2024-06-26
+memberType: H
+workingGroups:
+
+# sponsor
+sponsor:
+  level: 
+
+# Blog posts
+blog: 
+  url: 
+  feed: 
+  language: en_US
+
+# Press Releases
+press: 
+  url: 
+  feed: 
+  language: en_US
+
+# Careers
+careers: 
+  url: 
+  feed: 
+  language: en_US
+
+# Social media
+social:
+  twitter: 
+  facebook: 
+  instagram: 
+  linkedin: 
+  youtube: 
+
+# Here you can list those who represent or have represented the member.
+#
+# Those wo no longer represent an organization might have written blog posts,
+# to keep the attribution a from/till data range can be included.
+representatives:
+  - name: Troy Anderson
+    role: Technical Architect
+    social:
+      twitter: 
+      linkedin: 
+    description: Troy is the Technical Architect at Common Crypto Authority and represents the organization at the PKI Consortium.


### PR DESCRIPTION
Automatically generated pull request to add profile for Common Crypto Authority according to application pkic/members#309.

This closes pkic/members#309