### PR TITLE
Add pkimm-sticky-top-offset for visible header

### DIFF
--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -281,6 +281,6 @@ main h4 {
     }
 }
 
-.self-assessment {
+self-assessment {
     --pkimm-sticky-top-offset: 56px;
 }

--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -281,6 +281,6 @@ main h4 {
     }
 }
 
-self-assessment {
+.self-assessment {
     --pkimm-sticky-top-offset: 56px;
 }

--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -280,3 +280,7 @@ main h4 {
         font-size: 3.5rem;
     }
 }
+
+self-assessment {
+    --pkimm-sticky-top-offset: 56px;
+}

--- a/layouts/shortcodes/self-assessment.html
+++ b/layouts/shortcodes/self-assessment.html
@@ -1,3 +1,8 @@
+<style>
+    :root {
+        --pkimm-sticky-top-offset: 56px;
+    }
+</style>
 <self-assessment
     dataUrl="{{ with .Get "data-url" }}{{ . }}{{ else }}assessment-data.yaml{{ end }}"
     configUrl="{{ with .Get "config-url" }}{{ . }}{{ else }}config.yaml{{ end }}"

--- a/layouts/shortcodes/self-assessment.html
+++ b/layouts/shortcodes/self-assessment.html
@@ -1,5 +1,4 @@
 <self-assessment
-    class="self-assessment"
     dataUrl="{{ with .Get "data-url" }}{{ . }}{{ else }}assessment-data.yaml{{ end }}"
     configUrl="{{ with .Get "config-url" }}{{ . }}{{ else }}config.yaml{{ end }}"
 ></self-assessment>

--- a/layouts/shortcodes/self-assessment.html
+++ b/layouts/shortcodes/self-assessment.html
@@ -1,9 +1,5 @@
-<style>
-    :root {
-        --pkimm-sticky-top-offset: 56px;
-    }
-</style>
 <self-assessment
+    class="self-assessment"
     dataUrl="{{ with .Get "data-url" }}{{ . }}{{ else }}assessment-data.yaml{{ end }}"
     configUrl="{{ with .Get "config-url" }}{{ . }}{{ else }}config.yaml{{ end }}"
 ></self-assessment>


### PR DESCRIPTION
Add style to the self-assessment shortcode to keep the PKI MM self-assessment header visible together with the PKIC web site header