### PR TITLE
Add profile for Munich Reinsurance Group

### DIFF
--- a/data/members/munichre.yaml
+++ b/data/members/munichre.yaml
@@ -1,0 +1,55 @@
+id: munichre
+name: Munich Reinsurance Group
+slogan:
+website: https://www.munichre.com
+
+# Short description, longer content can be placed in `content/members/`
+description: Munich Re is a leading global provider of reinsurance, primary insurance and insurance-related risk solutions.
+
+
+# membership
+memberSince: 2025-03-07
+memberType: A
+workingGroups:
+
+# sponsor
+sponsor:
+  level: 
+
+# Blog posts
+blog: 
+  url: 
+  feed: 
+  language: en_US
+
+# Press Releases
+press: 
+  url: 
+  feed: 
+  language: en_US
+
+# Careers
+careers: 
+  url: 
+  feed: 
+  language: en_US
+
+# Social media
+social:
+  twitter: undefined
+  facebook: undefined
+  instagram: undefined
+  linkedin: undefined
+  youtube: undefined
+
+# Here you can list those who represent or have represented the member.
+#
+# Those wo no longer represent an organization might have written blog posts,
+# to keep the attribution a from/till data range can be included.
+representatives:
+  - name: Cosmin Stefan Marin
+    role: Senior IT Risk Technical Specialist
+    social:
+      twitter: 
+      linkedin: 
+    description: Cosmin Stefan is the Senior IT Risk Technical Specialist at Munich Reinsurance Group and represents the organization at the PKI Consortium.

--- a/data/members/munichre.yaml
+++ b/data/members/munichre.yaml
@@ -9,8 +9,11 @@ description: Munich Re is a leading global provider of reinsurance, primary insu
 
 # membership
 memberSince: 2025-03-07
-memberType: A
+memberType: H3
 workingGroups:
+  - PKIMM
+  - PQC
+  - TCWG
 
 # sponsor
 sponsor:
@@ -36,11 +39,11 @@ careers:
 
 # Social media
 social:
-  twitter: undefined
-  facebook: undefined
-  instagram: undefined
-  linkedin: undefined
-  youtube: undefined
+  twitter: 
+  facebook: 
+  instagram: 
+  linkedin: 
+  youtube: 
 
 # Here you can list those who represent or have represented the member.
 #
@@ -51,5 +54,5 @@ representatives:
     role: Senior IT Risk Technical Specialist
     social:
       twitter: 
-      linkedin: 
+      linkedin: https://www.linkedin.com/in/marincosmin
     description: Cosmin Stefan is the Senior IT Risk Technical Specialist at Munich Reinsurance Group and represents the organization at the PKI Consortium.


### PR DESCRIPTION
Automatically generated pull request to add profile for Munich Reinsurance Group according to application pkic/members#367.

This closes pkic/members#367