### PR TITLE
Add profile for Rwanda Information Society Authority (RISA)

### DIFF
--- a/data/members/risa.yaml
+++ b/data/members/risa.yaml
@@ -4,12 +4,16 @@ slogan:
 website: https://www.risa.gov.rw/
 
 # Short description, longer content can be placed in `content/members/`
-description: In our country (Rwanda), we have adopted the enhancement of digital security and trust using the PKI features. I am currently the head of the PKI department and on of the PKI pionners in the country. With the digitization journey that our country is currently following, we strongly believe that the use of PKI will help in building a strogn trust in the online exchanges.
+description: In our country (Rwanda), we have adopted the enhancement of digital security and trust using the PKI features.
 
 # membership
 memberSince: 2025-03-07
 memberType: A
 workingGroups:
+  - CA
+  - PKIMM
+  - PQC
+  - TCWG
 
 # sponsor
 sponsor:
@@ -35,11 +39,11 @@ careers:
 
 # Social media
 social:
-  twitter: undefined
-  facebook: undefined
-  instagram: undefined
-  linkedin: undefined
-  youtube: undefined
+  twitter: 
+  facebook: 
+  instagram: 
+  linkedin: 
+  youtube: 
 
 # Here you can list those who represent or have represented the member.
 #
@@ -50,5 +54,5 @@ representatives:
     role: National PKI Division Manager
     social:
       twitter: 
-      linkedin: 
+      linkedin: https://www.linkedin.com/in/bonaventure-karikumutima-a4127233/
     description: Bonaventure is the National PKI Division Manager at Rwanda Information Society Authority (RISA) and represents the organization at the PKI Consortium.

--- a/data/members/risa.yaml
+++ b/data/members/risa.yaml
@@ -1,0 +1,54 @@
+id: risa
+name: Rwanda Information Society Authority (RISA)
+slogan:
+website: https://www.risa.gov.rw/
+
+# Short description, longer content can be placed in `content/members/`
+description: In our country (Rwanda), we have adopted the enhancement of digital security and trust using the PKI features. I am currently the head of the PKI department and on of the PKI pionners in the country. With the digitization journey that our country is currently following, we strongly believe that the use of PKI will help in building a strogn trust in the online exchanges.
+
+# membership
+memberSince: 2025-03-07
+memberType: A
+workingGroups:
+
+# sponsor
+sponsor:
+  level: 
+
+# Blog posts
+blog: 
+  url: 
+  feed: 
+  language: en_US
+
+# Press Releases
+press: 
+  url: 
+  feed: 
+  language: en_US
+
+# Careers
+careers: 
+  url: 
+  feed: 
+  language: en_US
+
+# Social media
+social:
+  twitter: undefined
+  facebook: undefined
+  instagram: undefined
+  linkedin: undefined
+  youtube: undefined
+
+# Here you can list those who represent or have represented the member.
+#
+# Those wo no longer represent an organization might have written blog posts,
+# to keep the attribution a from/till data range can be included.
+representatives:
+  - name: Bonaventure KARIKUMUTIMA
+    role: National PKI Division Manager
+    social:
+      twitter: 
+      linkedin: 
+    description: Bonaventure is the National PKI Division Manager at Rwanda Information Society Authority (RISA) and represents the organization at the PKI Consortium.


### PR DESCRIPTION
Automatically generated pull request to add profile for Rwanda Information Society Authority (RISA) according to application pkic/members#366.

This closes pkic/members#366