### PR TITLE
Add profile for hubraum - technology incubator of Deutsche Telekom Group

### DIFF
--- a/data/members/hubraum.yaml
+++ b/data/members/hubraum.yaml
@@ -1,0 +1,54 @@
+id: hubraum
+name: hubraum - technology incubator of Deutsche Telekom Group
+slogan:
+website: https://www.hubraum.com/
+
+# Short description, longer content can be placed in `content/members/`
+description: Our tech incubator helps to take your product to the next level As startup incubator we offer coworking spaces, investments access to Deutsche Telekom
+
+# membership
+memberSince: 2025-03-07
+memberType: null
+workingGroups:
+
+# sponsor
+sponsor:
+  level: 
+
+# Blog posts
+blog: 
+  url: 
+  feed: 
+  language: en_US
+
+# Press Releases
+press: 
+  url: 
+  feed: 
+  language: en_US
+
+# Careers
+careers: 
+  url: 
+  feed: 
+  language: en_US
+
+# Social media
+social:
+  twitter: undefined
+  facebook: undefined
+  instagram: undefined
+  linkedin: undefined
+  youtube: undefined
+
+# Here you can list those who represent or have represented the member.
+#
+# Those wo no longer represent an organization might have written blog posts,
+# to keep the attribution a from/till data range can be included.
+representatives:
+  - name: Wojciech Pawlak
+    role: Technology Expert
+    social:
+      twitter: 
+      linkedin: 
+    description: Wojciech is the Technology Expert at hubraum - technology incubator of Deutsche Telekom Group and represents the organization at the PKI Consortium.

--- a/data/members/hubraum.yaml
+++ b/data/members/hubraum.yaml
@@ -8,8 +8,9 @@ description: Our tech incubator helps to take your product to the next level As 
 
 # membership
 memberSince: 2025-03-07
-memberType: null
+memberType: H2
 workingGroups:
+  - PQC
 
 # sponsor
 sponsor:
@@ -35,11 +36,11 @@ careers:
 
 # Social media
 social:
-  twitter: undefined
-  facebook: undefined
-  instagram: undefined
-  linkedin: undefined
-  youtube: undefined
+  twitter: 
+  facebook: 
+  instagram: 
+  linkedin: 
+  youtube: 
 
 # Here you can list those who represent or have represented the member.
 #
@@ -50,5 +51,5 @@ representatives:
     role: Technology Expert
     social:
       twitter: 
-      linkedin: 
+      linkedin: https://www.linkedin.com/in/wpawlak/
     description: Wojciech is the Technology Expert at hubraum - technology incubator of Deutsche Telekom Group and represents the organization at the PKI Consortium.


### PR DESCRIPTION
Automatically generated pull request to add profile for hubraum - technology incubator of Deutsche Telekom Group according to application pkic/members#456.

This closes pkic/members#456