### PR TITLE
Add profile for PLANCK RED PRIVATE LIMITED

### DIFF
--- a/data/members/planckred.yaml
+++ b/data/members/planckred.yaml
@@ -1,0 +1,54 @@
+id: planckred
+name: PLANCK RED PRIVATE LIMITED
+slogan:
+website: https://planckred.com/
+
+# Short description, longer content can be placed in `content/members/`
+description: Services to Government or Defense Data Centers  Banking/Financial sector edge computing nodes  Telecom & ISP edge POPs (Point of Presence)  Healthcare or citizen services in rural areas  IoT/SCADA systems in industrial environments
+
+# membership
+memberSince: 2025-04-29
+memberType: F
+workingGroups:
+
+# sponsor
+sponsor:
+  level: 
+
+# Blog posts
+blog: 
+  url: 
+  feed: https://planckred.com/feed/
+  language: en_US
+
+# Press Releases
+press: 
+  url: 
+  feed: 
+  language: en_US
+
+# Careers
+careers: 
+  url: 
+  feed: 
+  language: en_US
+
+# Social media
+social:
+  twitter: undefined
+  facebook: undefined
+  instagram: undefined
+  linkedin: undefined
+  youtube: undefined
+
+# Here you can list those who represent or have represented the member.
+#
+# Those wo no longer represent an organization might have written blog posts,
+# to keep the attribution a from/till data range can be included.
+representatives:
+  - name: SHISHIR MIGLANI
+    role: CEO
+    social:
+      twitter: 
+      linkedin: 
+    description: SHISHIR is the CEO at PLANCK RED PRIVATE LIMITED and represents the organization at the PKI Consortium.

--- a/data/members/planckred.yaml
+++ b/data/members/planckred.yaml
@@ -1,15 +1,18 @@
 id: planckred
-name: PLANCK RED PRIVATE LIMITED
+name: Plank Red Private Limited
 slogan:
 website: https://planckred.com/
 
 # Short description, longer content can be placed in `content/members/`
-description: Services to Government or Defense Data Centers  Banking/Financial sector edge computing nodes  Telecom & ISP edge POPs (Point of Presence)  Healthcare or citizen services in rural areas  IoT/SCADA systems in industrial environments
+description: Creating sustainable digital infrastructure to drive human proress
 
 # membership
 memberSince: 2025-04-29
 memberType: F
 workingGroups:
+  - PKIMM
+  - PQC
+  - TCWG
 
 # sponsor
 sponsor:
@@ -35,11 +38,11 @@ careers:
 
 # Social media
 social:
-  twitter: undefined
-  facebook: undefined
-  instagram: undefined
-  linkedin: undefined
-  youtube: undefined
+  twitter: 
+  facebook: 
+  instagram: 
+  linkedin: 
+  youtube: 
 
 # Here you can list those who represent or have represented the member.
 #
@@ -50,5 +53,5 @@ representatives:
     role: CEO
     social:
       twitter: 
-      linkedin: 
+      linkedin: https://www.linkedin.com/in/shishirmiglani
     description: SHISHIR is the CEO at PLANCK RED PRIVATE LIMITED and represents the organization at the PKI Consortium.


### PR DESCRIPTION
Automatically generated pull request to add profile for PLANCK RED PRIVATE LIMITED according to application pkic/members#490.

This closes pkic/members#490