### PR TITLE
Add information about the BD and EC

### DIFF
--- a/content/about/_index.md
+++ b/content/about/_index.md
@@ -39,7 +39,7 @@ The Public Key Infrastructure Consortium is comprised of leading organizations t
 
 The PKI Consortium is guided by a dedicated Board of Directors and an Executive Council, composed of industry leaders and experts. Their leadership ensures the consortium remains focused on its mission and vision.
 
-For more information, visit the [Board of Directors]({{< ref "/board/" >}}) and [Executive Council]({{< ref "/executive-council/" >}}) pages.
+For more information, visit the [Board of Directors]({{< ref "board/" >}}) and [Executive Council]({{< ref "executive-council/" >}}) pages.
 
 ## Members
 

--- a/content/about/_index.md
+++ b/content/about/_index.md
@@ -11,21 +11,42 @@ menu:
 ---
 
 ## About us
+
 {{< figure src="/img/logo-black.svg" alt="Logo of the PKI Consortium" height="100" class="float-lg-end" >}}
 
 The Public Key Infrastructure Consortium is comprised of leading organizations that are committed to improve, create and collaborate on generic, industry or use-case specific policies, procedures, best practices, standards and tools that advance trust in assets and communication for everyone and everything using Public Key Infrastructure (PKI) as well as the security of the internet in general. By engaging with users, regulators, supervisory bodies and other interested or relying parties the consortium can address actual issues. 
 
 ### Vision of the Public Key Infrastructure Consortium:
+
 > Trusted **digital assets** and **communication** for **everyone** and **everything**
 
 ### Mission statement of the Public Key Infrastructure Consortium:
+
 > Advance Trust in assets and communication for everyone and everything using Public Key Infrastructure (PKI) as well as the security of the internet in general, by engaging with users, regulators, supervisory bodies and other interested or relying parties
 
 ## History
+
 [Created in 2013](/2013/02/14/worlds-leading-certificate-authorities-come-together-to-advance-internet-security-and-the-trusted-ssl-ecosystem/) as the **Certificate Authority Security Council (CASC)** or **CA Security Council** in short. The orginal purpose was a multi-vendor industry advocacy group to conduct research, promote Internet security standards and educate the public on Internet security issues. In 2021 the CASC was restructred and renamed to the **The Public Key Infrastructure Consortium**, member fees where dropped and the focus was shifted to engagement and participation.
 
+## Leadership
+
+### Chair and Vice-chair
+
+* Chairmain: Paul van Brouwershaven
+* Vice-Chairman: Albert de Ruiter
+
+### Board of Directors and Executive Council
+
+The PKI Consortium is guided by a dedicated Board of Directors and an Executive Council, composed of industry leaders and experts. Their leadership ensures the consortium remains focused on its mission and vision.
+
+For more information, visit the [Board of Directors]({{< ref "/board/" >}}) and [Executive Council]({{< ref "/executive-council/" >}}) pages.
+
 ## Members
-Membership is currently available to publicly trusted Certificate Authorities, we are preparing to admit non CA members such as regulators, supervisory bodies and other interested parties. More information on how to become a member can be found at [here]({{< ref "/join.md" >}}).
+
+Membership in the PKI Consortium is open to organizations and individuals who are committed to advancing trust in digital assets and communication through Public Key Infrastructure (PKI). This includes Certificate Authorities, regulators, supervisory bodies, industry experts, and other stakeholders. Members collaborate on policies, best practices, and standards to enhance the security and trustworthiness of the internet. 
+
+For more information on how to become a member, visit [Join Us]({{< ref "/join/" >}}).
 
 ## Sponsors
+
 To support the activities of the PKI Consortium we accept sponsors and donations. Sponsors will be listed on the website but do not gain any other special treatment or rights. Sponsors can support the development of specific projects but will never be permitted to influence the outcome or a policy. More information on how to become a sponsor can be found at [here]({{< ref "/sponsors/" >}}).

--- a/content/about/board.md
+++ b/content/about/board.md
@@ -1,0 +1,22 @@
+---
+date: 2025-08-19T12:00:00Z
+title: Board of Directors
+
+heroTitle: Board of Directors
+heroDescription: Board of Directors of the PKI Consortium
+
+---
+
+The PKIC Board of Directors provides strategic leadership and governance for the organization, guiding its mission and vision. 
+
+## Current Members of the Board of Directors
+
+* **Chris Bailey** (Chairman of the Board) - Since March 2025
+* **Mads Henriksveen** - Since June 2022
+* **Dimitris Zacharopoulos** - Since June 2022
+* **Leo Grove** - Since June 2022
+* **Tim Callan** - Since June 2022
+
+## Former Members of the Board of Directors
+
+* **Kirk Hall** - Chairman of the Board from June 2022 - February 2025

--- a/content/about/executive-council.md
+++ b/content/about/executive-council.md
@@ -1,0 +1,32 @@
+---
+date: 2025-08-19T12:00:00Z
+title: Executive Council
+
+heroTitle: Executive Council
+heroDescription: Executive Council of the PKI Consortium
+
+---
+
+The Executive Council acts as a representative body of the PKI Consortium, ensuring efficient and effective governance on behalf of the broader membership. Adhering to the consortium's bylaws, this group is responsible for:
+
+* **Streamlining decisions**: Reviewing and deciding on matters that do not require full member discussion to avoid administrative burden and streamline communications.
+* **Member applications**: Ensuring the fair and correct processing of all member applications.
+* **Code of conduct**: Handling escalations related to the code of conduct.
+* **Sponsors and donations**: Overseeing the Sponsors and Donations program.
+* **Conflict resolution**: Deciding when consensus cannot be reached on key issues to ensure the consortium's work continues to move forward efficiently.
+
+## Current Members of the Executive Council
+
+* **Chris Bailey** (Chairman of Executive Council) - Since March 2025
+* **Paul van Brouwershaven** (Chairman of PKI Consortium) - Since January 2021
+* **Clemens Wanko** - Since June 2022
+* **Mads Henriksveen** - Since June 2022
+* **Dimitris Zacharopoulos** - Since June 2022
+* **Leo Grove** - Since June 2022
+* **Tim Callan** - Since June 2022
+* **Tomas Gustavsson** - Since June 2022
+* **Sudha E Iyer** - Since July 2024
+
+## Former Members of the Executive Council
+
+* **Kirk Hall** - Chairman of the Executive Council from June 2022 - February 2025


### PR DESCRIPTION
This pull request updates and expands the PKI Consortium's "About" section to provide clearer information about its leadership, membership, and governance. The changes include restructuring and renaming the main about page, adding dedicated pages for the Board of Directors and Executive Council, and revising membership and sponsorship details to be more inclusive and informative.

**Leadership and Governance Updates:**

* Added a new `board.md` page detailing the current and former members of the Board of Directors, including roles and dates of service.
* Added a new `executive-council.md` page outlining the responsibilities of the Executive Council, its current and former members, and its role in governance and decision-making.
* Expanded the main about page (`_index.md`) to introduce the Chair, Vice-Chair, Board of Directors, and Executive Council, with links to the new dedicated pages.

**Membership and Sponsorship Information:**

* Revised the membership section to clarify that membership is open to a wider range of organizations and individuals, not just Certificate Authorities, and updated the joining instructions.
