### PR TITLE
Add PQC AMS CFP blog post

### DIFF
--- a/content/blog/2026/20260512-cfp-pqc-amsterdam/index.md
+++ b/content/blog/2026/20260512-cfp-pqc-amsterdam/index.md
@@ -1,0 +1,62 @@
+---
+title: "Call for Proposals: Post-Quantum Cryptography Conference in Amsterdam, December 1-3, 2026"
+summary: |
+  The Post-Quantum Cryptography Conference is returning to Europe — Amsterdam, December 1-3, 2026. Our Call for Proposals is now open. The bar is simple: production experience over theory. If you have done the work, submit now.
+authors:
+  - Chris Bailey
+  - Paul van Brouwershaven
+date: 2026-05-12T08:00:00+00:00
+keywords: [PQC, Post-Quantum Cryptography, PQC Conference, Amsterdam, Call for Proposals, PKI Consortium]
+tags: [PQC, Post-Quantum Cryptography, PQC Conference, Amsterdam, Call for Proposals, PKI]
+
+params:
+    heroTitle: "Call for Proposals: Post-Quantum Cryptography Conference in Amsterdam, December 1-3, 2026"
+    heroImage: amsterdam-nl.png
+    heroDescription: The Call for Proposals is now open.
+---
+
+The Post-Quantum Cryptography Conference is returning to Europe (Amsterdam, December 1-3, 2026), and our Call for Proposals is now open at [pkic.org/call](https://pkic.org/call).
+
+If you watched the [aftermovie from Kuala Lumpur last October](https://youtu.be/Z8ZbbPcugz8), one line from the room captured the mood: 
+
+> It's like a tsunami coming — we just don't know when it's going to hit.
+
+That was 2,500+ attendees from 30+ countries, 71 speakers on stage, all wrestling with the same question — _where do we start?_ The community has stopped debating _whether_ the migration is coming and started debating _how_ to move without breaking the systems people rely on. [Amsterdam is where that conversation continues](/events/2026/pqc-conference-amsterdam-nl/).
+
+In-person registration is already at 80% of capacity, more than six months out. The program is filling alongside it. If you have something real to share, this is the time to submit.
+
+## What we look for
+
+The bar at our PQC Conferences is simple: **practical value over theory for its own sake**. We want educational sessions that help attendees go home with concrete plans, lessons learned, action items, better questions to ask, and new contacts who can help them move faster. Production experience is especially valuable, but so are standards, protocol, and cryptography sessions when they translate expert knowledge into decisions organizations need to make.
+
+We particularly value:
+
+- **Practitioner-led organization stories** — enterprises, governments, cloud providers, critical infrastructure operators, and other organizations doing the work themselves. Vendor co-submissions are welcome when the customer, operator, or implementation team owns the story and the audience gets a clear view of the real constraints.
+- **Standards and cryptography translated into action** — updates from people deeply involved in NIST, IETF, ETSI, ISO, CA/Browser Forum, and other relevant work, or from cryptographers and implementers who can explain what the choices mean for real systems, timelines, interoperability, and risk.
+- **Pilots, postmortems, and rollback lessons** — what failed, what had to be deferred, what broke in testing, what was rolled back, and what changed before the next attempt. A failed pilot with usable lessons is more valuable than a perfect roadmap with no evidence behind it.
+- **Multi-year migration programs and economics** — how you scoped the work, earned budget, set priorities, created ownership, measured progress, and decided what could wait.
+- **Regulatory and assurance navigation** — NIS2, DORA, CRA, sector-specific requirements, customer assurance pressure, and what auditors are actually asking for in practice.
+- **Deployment at scale** — cryptographic inventory and discovery, certificate automation, HSM and PKI infrastructure readiness, code signing, firmware signing, VPN/SSH, mTLS, CI/CD, workload identity, and the operational work that turns standards into functioning systems.
+- **Hard environments and sector realities** — OT networks with safety constraints and maintenance windows, IoT and field devices with long support cycles, remote sensors, transport systems, financial infrastructure, energy, agriculture, healthcare, telecom, manufacturing, and other places where the standard enterprise playbook is not enough.
+- **Supply-chain and vendor-readiness evidence** — procurement questions, support-period constraints, roadmap gaps, interoperability test results, and the evidence organizations need from suppliers before they can make credible migration commitments.
+
+## What disqualifies a submission
+
+Marketing language. Vendor pitches. Hypotheticals. Abstracts that say _"innovative solution"_ three times and never say what was built. The rule is simple — you are not allowed to pitch products or services on our stage.
+
+## The bench you'd be joining
+
+Recent speakers include Bill Newhouse and Andrew Regenscheid from NIST, the U.S. National Security Agency, Dutch government QvC leaders, Banco Santander, Cloudflare, IBM Research, Keyfactor, and the Malaysian Ministry of Digital. The implementation challenge has only become more urgent since they last took our stage. That is the caliber we are looking to match in Amsterdam.
+
+## Why submit now
+
+The community has cleared up the confusion about _where to start_ and _what the path forward looks like_ — and the people who built that clarity did it by getting on a stage and telling other practitioners what they learned. If you have done the work, you belong on that stage too.
+
+Submissions are open through the end of June. That said, we will start rolling out acceptances in the next few weeks — and when two proposals are substantially similar, we will prioritize the one submitted first. The earlier you submit, the better your odds.
+
+- **Submit a speaking proposal:** [pkic.org/call](https://pkic.org/call)
+- **Register to attend:** [pkic.org/register](https://pkic.org/register)
+
+If you are on the fence about whether your work belongs on this stage, submit anyway. We would rather see a rough abstract from someone with real migration experience than a polished one from someone with a commercial interest.
+
+Amsterdam, December 1-3. The room is filling. Save a seat by earning one.

--- a/content/blog/2026/20260512-cfp-pqc-amsterdam/index.md
+++ b/content/blog/2026/20260512-cfp-pqc-amsterdam/index.md
@@ -54,8 +54,8 @@ The community has cleared up the confusion about _where to start_ and _what the 
 
 Submissions are open through the end of June. That said, we will start rolling out acceptances in the next few weeks — and when two proposals are substantially similar, we will prioritize the one submitted first. The earlier you submit, the better your odds.
 
-- **Submit a speaking proposal:** [pkic.org/call](https://pkic.org/call)
-- **Register to attend:** [pkic.org/register](https://pkic.org/register)
+- **Submit a speaking proposal:** [pkic.org/call](/call)
+- **Register to attend:** [pkic.org/register](/register)
 
 If you are on the fence about whether your work belongs on this stage, submit anyway. We would rather see a rough abstract from someone with real migration experience than a polished one from someone with a commercial interest.
 

--- a/content/blog/2026/20260512-cfp-pqc-amsterdam/index.md
+++ b/content/blog/2026/20260512-cfp-pqc-amsterdam/index.md
@@ -52,7 +52,7 @@ Recent speakers include Bill Newhouse and Andrew Regenscheid from NIST, the U.S.
 
 The community has cleared up the confusion about _where to start_ and _what the path forward looks like_ — and the people who built that clarity did it by getting on a stage and telling other practitioners what they learned. If you have done the work, you belong on that stage too.
 
-Submissions are open through the end of June. That said, we will start rolling out acceptances in the next few weeks — and when two proposals are substantially similar, we will prioritize the one submitted first. The earlier you submit, the better your odds.
+Submissions are open through June 30, 2026. That said, we will start rolling out acceptances in the next few weeks — and when two proposals are substantially similar, we will prioritize the one submitted first. The earlier you submit, the better your odds.
 
 - **Submit a speaking proposal:** [pkic.org/call](/call)
 - **Register to attend:** [pkic.org/register](/register)

--- a/content/blog/2026/20260512-cfp-pqc-amsterdam/index.md
+++ b/content/blog/2026/20260512-cfp-pqc-amsterdam/index.md
@@ -15,7 +15,7 @@ params:
     heroDescription: The Call for Proposals is now open.
 ---
 
-The Post-Quantum Cryptography Conference is returning to Europe (Amsterdam, December 1-3, 2026), and our Call for Proposals is now open at [pkic.org/call](https://pkic.org/call).
+The Post-Quantum Cryptography Conference is returning to Europe (Amsterdam, December 1-3, 2026), and our Call for Proposals is now open at [pkic.org/call](/call).
 
 If you watched the [aftermovie from Kuala Lumpur last October](https://youtu.be/Z8ZbbPcugz8), one line from the room captured the mood: 
 


### PR DESCRIPTION
This pull request adds a new blog post announcing the Call for Proposals for the Post-Quantum Cryptography Conference in Amsterdam, scheduled for December 1-3, 2026. The post outlines the event details, submission guidelines, and the type of content sought for the conference.

New blog post addition:

* Added `content/blog/2026/20260512-cfp-pqc-amsterdam/index.md` with details about the conference, including submission criteria, topics of interest, disqualification criteria, and links for proposal submission and event registration.