### PR TITLE
Add PKIMM model version switcher

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,4 +13,3 @@
 [submodule "content/pkimm-1.0.0"]
 	path = content/wg/pkimm/1.0.0
 	url = ../pkimm
-	branch = 1.0.0

--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,7 @@
 	path = content/wg/cm/remote-key-attestation
 	url = ../remote-key-attestation.git
 	branch = main
+[submodule "content/pkimm-1.0.0"]
+	path = content/wg/pkimm/1.0.0
+	url = ../pkimm
+	branch = 1.0.0

--- a/assets/scss/_working-groups-sections.scss
+++ b/assets/scss/_working-groups-sections.scss
@@ -50,6 +50,140 @@
       border-bottom-color: var(--wg-color, #{$green}); // matches WG color
     }
   }
+
+  // ─── Version switcher (PKIMM) ────────────────────────────────────────
+  // A small dropdown anchored to the right of the section nav. Reuses the
+  // same dark palette and font scale as .wg-nav-link so it reads as part
+  // of the same control bar.
+  .wg-version-switcher {
+    margin-left: auto;
+    position: relative;
+    align-self: stretch;
+    display: flex;
+    align-items: center;
+
+    // Hide the default <details>/<summary> marker
+    summary {
+      list-style: none;
+      cursor: pointer;
+      display: inline-flex;
+      align-items: center;
+      gap: 0.45rem;
+      padding: 0.4rem 0.7rem;
+      font-size: 0.78rem;
+      font-weight: 600;
+      letter-spacing: 0.04em;
+      color: rgba(255, 255, 255, 0.55);
+      border: 1px solid rgba(255, 255, 255, 0.14);
+      border-radius: 0.4rem;
+      white-space: nowrap;
+      transition:
+        color 0.15s,
+        border-color 0.15s,
+        background 0.15s;
+
+      &::-webkit-details-marker {
+        display: none;
+      }
+      &:hover {
+        color: #fff;
+        border-color: rgba(255, 255, 255, 0.28);
+        background: rgba(255, 255, 255, 0.04);
+      }
+    }
+
+    &[open] summary {
+      color: #fff;
+      border-color: var(--wg-color, #{$green});
+      background: rgba(255, 255, 255, 0.06);
+    }
+  }
+
+  .wg-version-eyebrow {
+    font-size: 0.65rem;
+    font-weight: 700;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: rgba(255, 255, 255, 0.4);
+  }
+
+  .wg-version-chevron {
+    transition: transform 0.15s ease;
+    opacity: 0.75;
+  }
+  .wg-version-switcher[open] .wg-version-chevron {
+    transform: rotate(180deg);
+  }
+
+  // ─── Badge — the version label itself ───────────────────────────────
+  // Used in the trigger (showing the current version) and in each menu
+  // entry (showing that entry's version).
+  .wg-version-badge {
+    display: inline-block;
+    padding: 0.15rem 0.45rem;
+    font-size: 0.7rem;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    line-height: 1.3;
+    border-radius: 0.3rem;
+    background: rgba(255, 255, 255, 0.12);
+    color: #fff;
+  }
+
+  // ─── Menu (the dropdown that appears below the trigger) ─────────────
+  // Positioned `fixed` so it escapes the .container's `overflow-x: auto`
+  // clip. The partial's JS sets `top`/`right` from the trigger's bounding
+  // rect on open and on scroll/resize.
+  .wg-version-menu {
+    position: fixed;
+    top: 0;
+    right: 0;
+    z-index: 1050;
+    min-width: 14rem;
+    padding: 0.35rem;
+    background: #111;
+    border: 1px solid rgba(255, 255, 255, 0.14);
+    border-radius: 0.5rem;
+    box-shadow:
+      0 12px 28px rgba(0, 0, 0, 0.5),
+      0 0 0 1px rgba(0, 0, 0, 0.4);
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+
+  .wg-version-item {
+    display: flex;
+    align-items: center;
+    gap: 0.55rem;
+    padding: 0.5rem 0.6rem;
+    color: rgba(255, 255, 255, 0.78);
+    text-decoration: none;
+    border-radius: 0.35rem;
+    transition:
+      color 0.12s,
+      background 0.12s;
+
+    &:hover {
+      color: #fff;
+      background: rgba(255, 255, 255, 0.06);
+    }
+
+    &.is-active {
+      color: #fff;
+      background: rgba(255, 255, 255, 0.08);
+      box-shadow: inset 2px 0 0 var(--wg-color, #{$green});
+    }
+  }
+
+  // Secondary inline hint next to the badge, e.g. "Latest release".
+  .wg-version-hint {
+    font-size: 0.65rem;
+    font-weight: 600;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: color-mix(in srgb, #{$green} 80%, #fff);
+  }
 }
 
 // Data-driven WG section pages (Focus Areas, Deliverables, Members, etc.).

--- a/config.yaml
+++ b/config.yaml
@@ -68,6 +68,8 @@ params:
   submoduleSources:
     - prefix: wg/pkimm/model/
       source: https://github.com/pkic/pkimm/edit/main
+    - prefix: wg/pkimm/1.0.0/
+      source: https://github.com/pkic/pkimm/blob/1.0.0
     - prefix: wg/cm/remote-key-attestation/
       source: https://github.com/pkic/remote-key-attestation/edit/main
     - prefix: wg/pqc/pqccm/

--- a/content/wg/pkimm/_index.md
+++ b/content/wg/pkimm/_index.md
@@ -32,13 +32,13 @@ chair:
 keyDeliverables:
   - title: PKI Maturity Model
     description: A complete five-level framework for evaluating and benchmarking PKI implementations across all critical domains — from governance and risk management to cryptographic controls and certificate lifecycle.
-    url: /wg/pkimm/model/
+    url: /wg/pkimm/1.0.0/
     icon: pkimm-model
     cta: Explore the Model
     badge: Active
   - title: Online Quick Assessment
     description: Assess your organization's PKI maturity in minutes. The interactive self-assessment scores your PKI across all domains and provides an instant gap analysis with actionable recommendations — no login required.
-    url: /wg/pkimm/model/tools/self-assessment/
+    url: /wg/pkimm/1.0.0/tools/self-assessment/
     icon: pkimm-assessment
     cta: Start Free Assessment
     badge: Free · No login required
@@ -50,10 +50,10 @@ card:
   description: "A globally recognized standard for evaluating, planning and comparing PKI implementations across every sector."
   links:
     - text: "Maturity Model"
-      url: "/wg/pkimm/model/"
+      url: "/wg/pkimm/1.0.0/"
       chip: primary
     - text: "Assessment Tools"
-      url: "/wg/pkimm/model/tools/"
+      url: "/wg/pkimm/1.0.0/tools/"
       chip: secondary
     - text: "Blog Posts"
       url: "/tags/pkimm/"
@@ -94,7 +94,7 @@ deliverables:
   - title: PKI Maturity Model
     menuTitle: Model
     description: The foundational maturity model framework with defined levels, domains, and criteria.
-    url: /wg/pkimm/model/
+    url: /wg/pkimm/1.0.0/
     status: active
   - title: PKIMM Certification Program
     description: A formal assessment and certification program for organizations seeking recognized PKIMM validation.
@@ -102,7 +102,7 @@ deliverables:
 
 resources:
   - title: PKIMM Self-Assessment Tool
-    url: /wg/pkimm/model/tools/
+    url: /wg/pkimm/1.0.0/tools/
     description: Use the interactive tool to assess your organization's PKI maturity level.
   - title: NIST Cybersecurity Framework
     url: https://www.nist.gov/cyberframework

--- a/data/pkimm-versions.yaml
+++ b/data/pkimm-versions.yaml
@@ -1,0 +1,26 @@
+# Registry of PKIMM model versions rendered on the site.
+#
+# Each entry corresponds to a content subtree mounted via a git submodule
+# under `content/wg/pkimm/`. The version switcher partial reads this file
+# to render its dropdown and route between versions.
+#
+# Fields:
+#   id               URL segment under /wg/pkimm/ — used to detect the
+#                    current version from the page path
+#   label            short text rendered as a pill badge in the switcher
+#   path             absolute site path of this version's root
+#   isLatestRelease  true for the most recent stable release — shows a
+#                    "Latest release" hint under the entry in the menu
+#
+# Entries are listed in the order they appear in the dropdown. Put the
+# recommended landing version first.
+
+versions:
+  - id: "1.0.0"
+    label: "1.0.0"
+    path: /wg/pkimm/1.0.0/
+    isLatestRelease: true
+
+  - id: model
+    label: "main"
+    path: /wg/pkimm/model/

--- a/layouts/partials/wg/pkimm-version-switcher.html
+++ b/layouts/partials/wg/pkimm-version-switcher.html
@@ -63,22 +63,16 @@
     window.addEventListener('scroll', positionMenu, { passive: true });
     window.addEventListener('resize', positionMenu);
 
-    // Path-preserving navigation with 404 fallback.
+    // Path-preserving navigation: rewrite each version link's href to the
+    // equivalent sub-path under that version, so the user stays on the same
+    // page when switching. If a target page doesn't exist in the target
+    // version (structural divergence between versions), the click falls
+    // through to Hugo's 404 page — accepted trade-off to keep clicks
+    // instant and the script simple.
     if (path.indexOf(currentBase) === 0) {
       var subPath = path.slice(currentBase.length);
       sw.querySelectorAll('a[data-version-path]').forEach(function (a) {
         a.href = a.dataset.versionPath + subPath;
-        a.addEventListener('click', function (ev) {
-          var href = a.href;
-          ev.preventDefault();
-          fetch(href, { method: 'HEAD' })
-            .then(function (res) {
-              window.location.href = res.ok ? href : a.dataset.versionPath;
-            })
-            .catch(function () {
-              window.location.href = a.dataset.versionPath;
-            });
-        });
       });
     }
 

--- a/layouts/partials/wg/pkimm-version-switcher.html
+++ b/layouts/partials/wg/pkimm-version-switcher.html
@@ -1,0 +1,92 @@
+{{/*
+  PKIMM version switcher.
+  Rendered inside the sticky .wg-section-nav for PKIMM pages. Reads
+  data/pkimm-versions.yaml, detects the current version from the page
+  URL, and emits a <details> dropdown with one <a> per version. A small
+  inline script rewrites those hrefs on click so switching preserves
+  the in-version sub-path (falls back to the version root on 404).
+*/}}
+{{- $versions := index $.Site.Data "pkimm-versions" -}}
+{{- if and $versions $versions.versions -}}
+  {{- $current := "" -}}
+  {{- $currentLabel := "" -}}
+  {{- range $versions.versions -}}
+    {{- if and (not $current) (strings.HasPrefix $.RelPermalink .path) -}}
+      {{- $current = .id -}}
+      {{- $currentLabel = .label -}}
+    {{- end -}}
+  {{- end -}}
+  {{- if $current -}}
+<details class="wg-version-switcher" data-current="{{ $current }}">
+  <summary aria-label="Switch model version">
+    <span class="wg-version-eyebrow">Version</span>
+    <span class="wg-version-badge">{{ $currentLabel }}</span>
+    <svg class="wg-version-chevron" xmlns="http://www.w3.org/2000/svg" width="11" height="11" viewBox="0 0 24 24"
+         fill="none" stroke="currentColor" stroke-width="2.5"
+         stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+      <polyline points="6 9 12 15 18 9"/>
+    </svg>
+  </summary>
+  <div class="wg-version-menu" role="menu">
+    {{ range $versions.versions }}
+    <a class="wg-version-item{{ if eq $current .id }} is-active{{ end }}"
+       href="{{ .path }}"
+       data-version-path="{{ .path }}"
+       role="menuitem">
+      <span class="wg-version-badge">{{ .label }}</span>
+      {{- if .isLatestRelease }}
+      <span class="wg-version-hint">Latest release</span>
+      {{- end }}
+    </a>
+    {{ end }}
+  </div>
+</details>
+<script>
+  (function () {
+    var sw = document.currentScript.previousElementSibling;
+    if (!sw || !sw.classList.contains('wg-version-switcher')) return;
+    var summary = sw.querySelector('summary');
+    var menu = sw.querySelector('.wg-version-menu');
+    var currentBase = '/wg/pkimm/' + sw.dataset.current + '/';
+    var path = window.location.pathname;
+
+    // Position the menu under the trigger. The menu is position:fixed so it
+    // escapes the .container overflow clip; we set top/right here from the
+    // trigger's bounding rect.
+    function positionMenu() {
+      if (!sw.open) return;
+      var rect = summary.getBoundingClientRect();
+      menu.style.top = (rect.bottom + 4) + 'px';
+      menu.style.right = (window.innerWidth - rect.right) + 'px';
+    }
+    sw.addEventListener('toggle', positionMenu);
+    window.addEventListener('scroll', positionMenu, { passive: true });
+    window.addEventListener('resize', positionMenu);
+
+    // Path-preserving navigation with 404 fallback.
+    if (path.indexOf(currentBase) === 0) {
+      var subPath = path.slice(currentBase.length);
+      sw.querySelectorAll('a[data-version-path]').forEach(function (a) {
+        a.href = a.dataset.versionPath + subPath;
+        a.addEventListener('click', function (ev) {
+          var href = a.href;
+          ev.preventDefault();
+          fetch(href, { method: 'HEAD' })
+            .then(function (res) {
+              window.location.href = res.ok ? href : a.dataset.versionPath;
+            })
+            .catch(function () {
+              window.location.href = a.dataset.versionPath;
+            });
+        });
+      });
+    }
+
+    // Close on outside click.
+    document.addEventListener('click', function (ev) {
+      if (sw.open && !sw.contains(ev.target)) sw.open = false;
+    });
+  })();
+</script>
+  {{- end -}}
+{{- end -}}

--- a/layouts/partials/wg/sub-navigation.html
+++ b/layouts/partials/wg/sub-navigation.html
@@ -145,6 +145,10 @@
     {{ end }}
 
     <a class="wg-nav-link" href="/blog/?wg={{ $wg.Params.wgID | lower }}">Blog</a>
+
+    {{ if eq ($wg.Params.wgID | upper) "PKIMM" }}
+    {{ partial "wg/pkimm-version-switcher.html" . }}
+    {{ end }}
   </div>
 </nav>
 {{/* Tree panels — one per deliverable section with child pages */}}

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -75,6 +75,20 @@ else
 fi
 
 # ── Build ─────────────────────────────────────────────────────────────────────
-git submodule update --init --remote
+# Clone any missing submodules at the SHAs recorded in the parent commit.
+git submodule update --init --recursive
+
+# Refresh submodules that track a moving branch (have `branch = ...` in
+# .gitmodules) to the latest tip of that branch. Submodules pinned to a
+# specific commit — typically frozen version snapshots like
+# content/wg/pkimm/1.0.0 — have no `branch` field and stay at the recorded
+# SHA so they don't drift.
+while IFS= read -r entry; do
+  name="${entry#submodule.}"
+  name="${name%.branch}"
+  path="$(git config -f .gitmodules --get "submodule.${name}.path")"
+  [ -n "$path" ] && git submodule update --remote -- "$path"
+done < <(git config -f .gitmodules --name-only --get-regexp '^submodule\..*\.branch$')
+
 "${HUGO_BIN}" -e development --minify --cacheDir "$(pwd)/.cache"
 npx -y pagefind --site "public"


### PR DESCRIPTION
Adds a version switcher to PKIMM model pages so users can toggle between in-development content (`main`) and tagged releases. New visitors land on the latest stable release (`1.0.0`) by default.

## Changes

- New submodule `content/wg/pkimm/1.0.0` pinned at the [`1.0.0`](https://github.com/pkic/pkimm/releases/tag/1.0.0) tag
- `data/pkimm-versions.yaml` — version registry
- `layouts/partials/wg/pkimm-version-switcher.html` — dropdown partial; preserves sub-path when switching, 404 fallback to the version root
- `layouts/partials/wg/sub-navigation.html` — inject the partial, scoped to `wgID == "PKIMM"`
- `assets/scss/_working-groups-sections.scss` — switcher styles
- `config.yaml` — `wg/pkimm/1.0.0/` maps to a read-only blob view
- `content/wg/pkimm/_index.md` — entry-point URLs now target `/wg/pkimm/1.0.0/`