### PR TITLE
Fix PKIMM version switcher

### DIFF
--- a/assets/js/modules/global-ui.js
+++ b/assets/js/modules/global-ui.js
@@ -146,3 +146,4 @@ document.querySelectorAll('time[datetime]').forEach(function ($e) {
     });
   });
 })();
+

--- a/assets/js/modules/global-ui.js
+++ b/assets/js/modules/global-ui.js
@@ -146,4 +146,3 @@ document.querySelectorAll('time[datetime]').forEach(function ($e) {
     });
   });
 })();
-

--- a/assets/scss/_working-groups-sections.scss
+++ b/assets/scss/_working-groups-sections.scss
@@ -51,139 +51,95 @@
     }
   }
 
-  // ─── Version switcher (PKIMM) ────────────────────────────────────────
-  // A small dropdown anchored to the right of the section nav. Reuses the
-  // same dark palette and font scale as .wg-nav-link so it reads as part
-  // of the same control bar.
-  .wg-version-switcher {
-    margin-left: auto;
-    position: relative;
-    align-self: stretch;
-    display: flex;
-    align-items: center;
+}
 
-    // Hide the default <details>/<summary> marker
-    summary {
-      list-style: none;
-      cursor: pointer;
-      display: inline-flex;
-      align-items: center;
-      gap: 0.45rem;
-      padding: 0.4rem 0.7rem;
-      font-size: 0.78rem;
-      font-weight: 600;
-      letter-spacing: 0.04em;
-      color: rgba(255, 255, 255, 0.55);
-      border: 1px solid rgba(255, 255, 255, 0.14);
-      border-radius: 0.4rem;
-      white-space: nowrap;
-      transition:
-        color 0.15s,
-        border-color 0.15s,
-        background 0.15s;
+// ─── Version switcher (PKIMM) ──────────────────────────────────────────
+// Rendered as a footer block at the bottom of the Model tree panel (see
+// layouts/partials/wg/pkimm-version-switcher.html). Lives inside the
+// `.wg-nav-tree-panel`, which already handles its own positioning, so the
+// switcher itself is in normal flow — no `position: fixed`, no JS-driven
+// repositioning. Path-preserving link rewriting is handled in
+// assets/js/modules/global-ui.js.
 
-      &::-webkit-details-marker {
-        display: none;
-      }
-      &:hover {
-        color: #fff;
-        border-color: rgba(255, 255, 255, 0.28);
-        background: rgba(255, 255, 255, 0.04);
-      }
-    }
+.wg-version-switcher {
+  margin-top: 0.75rem;
+  padding-top: 0.75rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
 
-    &[open] summary {
-      color: #fff;
-      border-color: var(--wg-color, #{$green});
-      background: rgba(255, 255, 255, 0.06);
-    }
-  }
+.wg-version-eyebrow {
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.45);
+  margin: 0 0 0.4rem 0.25rem;
+}
 
-  .wg-version-eyebrow {
-    font-size: 0.65rem;
-    font-weight: 700;
-    letter-spacing: 0.12em;
-    text-transform: uppercase;
-    color: rgba(255, 255, 255, 0.4);
-  }
+.wg-version-list {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  // Cap at ~4 items so a long version history stays bounded inside the
+  // tree panel; shorter lists never see a scrollbar.
+  max-height: 9.5rem;
+  overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(255, 255, 255, 0.15) transparent;
+}
 
-  .wg-version-chevron {
-    transition: transform 0.15s ease;
-    opacity: 0.75;
-  }
-  .wg-version-switcher[open] .wg-version-chevron {
-    transform: rotate(180deg);
-  }
+.wg-version-item {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  padding: 0.45rem 0.55rem;
+  color: rgba(255, 255, 255, 0.78);
+  text-decoration: none;
+  border-radius: 0.35rem;
+  transition:
+    color 0.12s,
+    background 0.12s;
 
-  // ─── Badge — the version label itself ───────────────────────────────
-  // Used in the trigger (showing the current version) and in each menu
-  // entry (showing that entry's version).
-  .wg-version-badge {
-    display: inline-block;
-    padding: 0.15rem 0.45rem;
-    font-size: 0.7rem;
-    font-weight: 700;
-    letter-spacing: 0.04em;
-    line-height: 1.3;
-    border-radius: 0.3rem;
-    background: rgba(255, 255, 255, 0.12);
+  &:hover {
     color: #fff;
-  }
-
-  // ─── Menu (the dropdown that appears below the trigger) ─────────────
-  // Positioned `fixed` so it escapes the .container's `overflow-x: auto`
-  // clip. The partial's JS sets `top`/`right` from the trigger's bounding
-  // rect on open and on scroll/resize.
-  .wg-version-menu {
-    position: fixed;
-    top: 0;
-    right: 0;
-    z-index: 1050;
-    min-width: 14rem;
-    padding: 0.35rem;
-    background: #111;
-    border: 1px solid rgba(255, 255, 255, 0.14);
-    border-radius: 0.5rem;
-    box-shadow:
-      0 12px 28px rgba(0, 0, 0, 0.5),
-      0 0 0 1px rgba(0, 0, 0, 0.4);
-    display: flex;
-    flex-direction: column;
-    gap: 2px;
-  }
-
-  .wg-version-item {
-    display: flex;
-    align-items: center;
-    gap: 0.55rem;
-    padding: 0.5rem 0.6rem;
-    color: rgba(255, 255, 255, 0.78);
+    background: rgba(255, 255, 255, 0.06);
     text-decoration: none;
-    border-radius: 0.35rem;
-    transition:
-      color 0.12s,
-      background 0.12s;
-
-    &:hover {
-      color: #fff;
-      background: rgba(255, 255, 255, 0.06);
-    }
-
-    &.is-active {
-      color: #fff;
-      background: rgba(255, 255, 255, 0.08);
-      box-shadow: inset 2px 0 0 var(--wg-color, #{$green});
-    }
   }
 
-  // Secondary inline hint next to the badge, e.g. "Latest release".
-  .wg-version-hint {
-    font-size: 0.65rem;
-    font-weight: 600;
-    letter-spacing: 0.06em;
-    text-transform: uppercase;
-    color: color-mix(in srgb, #{$green} 80%, #fff);
+  &.is-active {
+    color: #fff;
+    background: rgba(255, 255, 255, 0.08);
+    box-shadow: inset 2px 0 0 var(--wg-color, #{$green});
   }
+}
+
+// The version label itself, rendered as a pill badge.
+.wg-version-badge {
+  display: inline-block;
+  padding: 0.15rem 0.45rem;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  line-height: 1.3;
+  border-radius: 0.3rem;
+  background: rgba(255, 255, 255, 0.12);
+  color: #fff;
+}
+
+// Secondary inline hint next to the badge, e.g. "Latest release".
+.wg-version-hint {
+  font-size: 0.65rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, #{$green} 80%, #fff);
+}
+
+// Shown when the current page does not exist in the target version — the
+// link falls back to that version's overview/root. Toned down vs the green
+// "Latest release" hint so it reads as an advisory, not a feature.
+.wg-version-hint--fallback {
+  color: rgba(255, 255, 255, 0.45);
 }
 
 // Data-driven WG section pages (Focus Areas, Deliverables, Members, etc.).

--- a/assets/scss/_working-groups-sections.scss
+++ b/assets/scss/_working-groups-sections.scss
@@ -58,8 +58,8 @@
 // layouts/partials/wg/pkimm-version-switcher.html). Lives inside the
 // `.wg-nav-tree-panel`, which already handles its own positioning, so the
 // switcher itself is in normal flow — no `position: fixed`, no JS-driven
-// repositioning. Path-preserving link rewriting is handled in
-// assets/js/modules/global-ui.js.
+// repositioning. Path-preserving link rewriting is resolved at build time
+// in layouts/partials/wg/pkimm-version-switcher.html.
 
 .wg-version-switcher {
   margin-top: 0.75rem;

--- a/layouts/partials/wg/pkimm-version-switcher.html
+++ b/layouts/partials/wg/pkimm-version-switcher.html
@@ -1,86 +1,57 @@
 {{/*
   PKIMM version switcher.
-  Rendered inside the sticky .wg-section-nav for PKIMM pages. Reads
-  data/pkimm-versions.yaml, detects the current version from the page
-  URL, and emits a <details> dropdown with one <a> per version. A small
-  inline script rewrites those hrefs on click so switching preserves
-  the in-version sub-path (falls back to the version root on 404).
+
+  Renders inline at the bottom of the Model tree panel (see
+  layouts/partials/wg/sub-navigation.html and its sibling layouts). Reads
+  data/pkimm-versions.yaml, detects the current version from the page URL,
+  and emits one link per version.
+
+  Path preservation is resolved at build time: for each non-current version
+  we ask Hugo whether the equivalent sub-path exists in that version's
+  content tree. If yes, link to the sub-path; if not, fall back to the
+  version root. This eliminates runtime 404s when versions diverge
+  structurally and removes the need for any client-side href rewriting.
 */}}
 {{- $versions := index $.Site.Data "pkimm-versions" -}}
 {{- if and $versions $versions.versions -}}
   {{- $current := "" -}}
-  {{- $currentLabel := "" -}}
+  {{- $currentPath := "" -}}
   {{- range $versions.versions -}}
     {{- if and (not $current) (strings.HasPrefix $.RelPermalink .path) -}}
       {{- $current = .id -}}
-      {{- $currentLabel = .label -}}
+      {{- $currentPath = .path -}}
     {{- end -}}
   {{- end -}}
-  {{- if $current -}}
-<details class="wg-version-switcher" data-current="{{ $current }}">
-  <summary aria-label="Switch model version">
-    <span class="wg-version-eyebrow">Version</span>
-    <span class="wg-version-badge">{{ $currentLabel }}</span>
-    <svg class="wg-version-chevron" xmlns="http://www.w3.org/2000/svg" width="11" height="11" viewBox="0 0 24 24"
-         fill="none" stroke="currentColor" stroke-width="2.5"
-         stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-      <polyline points="6 9 12 15 18 9"/>
-    </svg>
-  </summary>
-  <div class="wg-version-menu" role="menu">
-    {{ range $versions.versions }}
-    <a class="wg-version-item{{ if eq $current .id }} is-active{{ end }}"
-       href="{{ .path }}"
-       data-version-path="{{ .path }}"
-       role="menuitem">
+  {{- $subPath := "" -}}
+  {{- if $currentPath -}}
+    {{- $subPath = strings.TrimPrefix $currentPath $.RelPermalink -}}
+  {{- end -}}
+<div class="wg-version-switcher" data-current="{{ $current }}">
+  <p class="wg-version-eyebrow">Switch version</p>
+  <div class="wg-version-list" role="group" aria-label="Switch PKIMM model version">
+    {{- range $versions.versions -}}
+      {{- $href := .path -}}
+      {{- $exists := true -}}
+      {{- if eq .id $current -}}
+        {{- $href = $.RelPermalink -}}
+      {{- else if $subPath -}}
+        {{- $candidate := printf "%s%s" .path $subPath -}}
+        {{- if $.Site.GetPage $candidate -}}
+          {{- $href = $candidate -}}
+        {{- else -}}
+          {{- $exists = false -}}
+        {{- end -}}
+      {{- end -}}
+    <a class="wg-version-item{{ if eq $current .id }} is-active{{ end }}" href="{{ $href }}">
       <span class="wg-version-badge">{{ .label }}</span>
       {{- if .isLatestRelease }}
       <span class="wg-version-hint">Latest release</span>
       {{- end }}
+      {{- if not $exists }}
+      <span class="wg-version-hint wg-version-hint--fallback" title="This page is not available in {{ .label }} — go to the version overview instead">Overview</span>
+      {{- end }}
     </a>
-    {{ end }}
+    {{- end }}
   </div>
-</details>
-<script>
-  (function () {
-    var sw = document.currentScript.previousElementSibling;
-    if (!sw || !sw.classList.contains('wg-version-switcher')) return;
-    var summary = sw.querySelector('summary');
-    var menu = sw.querySelector('.wg-version-menu');
-    var currentBase = '/wg/pkimm/' + sw.dataset.current + '/';
-    var path = window.location.pathname;
-
-    // Position the menu under the trigger. The menu is position:fixed so it
-    // escapes the .container overflow clip; we set top/right here from the
-    // trigger's bounding rect.
-    function positionMenu() {
-      if (!sw.open) return;
-      var rect = summary.getBoundingClientRect();
-      menu.style.top = (rect.bottom + 4) + 'px';
-      menu.style.right = (window.innerWidth - rect.right) + 'px';
-    }
-    sw.addEventListener('toggle', positionMenu);
-    window.addEventListener('scroll', positionMenu, { passive: true });
-    window.addEventListener('resize', positionMenu);
-
-    // Path-preserving navigation: rewrite each version link's href to the
-    // equivalent sub-path under that version, so the user stays on the same
-    // page when switching. If a target page doesn't exist in the target
-    // version (structural divergence between versions), the click falls
-    // through to Hugo's 404 page — accepted trade-off to keep clicks
-    // instant and the script simple.
-    if (path.indexOf(currentBase) === 0) {
-      var subPath = path.slice(currentBase.length);
-      sw.querySelectorAll('a[data-version-path]').forEach(function (a) {
-        a.href = a.dataset.versionPath + subPath;
-      });
-    }
-
-    // Close on outside click.
-    document.addEventListener('click', function (ev) {
-      if (sw.open && !sw.contains(ev.target)) sw.open = false;
-    });
-  })();
-</script>
-  {{- end -}}
+</div>
 {{- end -}}

--- a/layouts/partials/wg/sub-navigation.html
+++ b/layouts/partials/wg/sub-navigation.html
@@ -192,7 +192,7 @@
       {{- $treePage := cond $isActive $.Page $delSection -}}
 <div class="wg-nav-tree-panel wg-{{ $wg.Params.wgID | lower }}" id="wg-nav-tree-{{ $slug }}" hidden>
   {{ partial "wg/sidebar-tree.html" $treePage }}
-  {{ if eq ($wg.Params.wgID | upper) "PKIMM" }}
+  {{ if $isPkimm }}
   {{ partial "wg/pkimm-version-switcher.html" $.Page }}
   {{ end }}
 </div>

--- a/layouts/partials/wg/sub-navigation.html
+++ b/layouts/partials/wg/sub-navigation.html
@@ -66,6 +66,26 @@
     {{- end -}}
   {{- end -}}
 {{- end -}}
+{{/* PKIMM version awareness: deliverable URLs in _index.md are pinned to one
+     version (e.g. /wg/pkimm/1.0.0/), but on a sibling version page (e.g.
+     /wg/pkimm/model/...) those URLs should follow the current version so the
+     tree panel shows the user's own version's pages and the tab highlights
+     correctly. We detect the current version base and the pinned version base
+     from data/pkimm-versions.yaml, then rewrite each deliverable URL below. */}}
+{{- $isPkimm := eq ($wg.Params.wgID | upper) "PKIMM" -}}
+{{- $pkimmVersions := slice -}}
+{{- $pkimmCurrentBase := "" -}}
+{{- if $isPkimm -}}
+  {{- $data := index $.Site.Data "pkimm-versions" -}}
+  {{- if and $data $data.versions -}}
+    {{- $pkimmVersions = $data.versions -}}
+    {{- range $pkimmVersions -}}
+      {{- if and (not $pkimmCurrentBase) (strings.HasPrefix $.Page.RelPermalink .path) -}}
+        {{- $pkimmCurrentBase = .path -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
 <nav class="wg-section-nav wg-{{ $wg.Params.wgID | lower }}" id="wgSectionNav" aria-label="Page sections">
   <div class="container d-flex gap-1">
     <a class="wg-nav-link{{ if eq $.Page.RelPermalink $base }} is-active{{ end }}" href="{{ $base }}">About</a>
@@ -83,6 +103,13 @@
     {{- $hasDelivLink := false -}}
     {{- range $wg.Params.deliverables -}}
       {{- $delURL := .url | default "" -}}
+      {{- if and $isPkimm $pkimmCurrentBase $delURL -}}
+        {{- range $pkimmVersions -}}
+          {{- if and (strings.HasPrefix $delURL .path) (ne .path $pkimmCurrentBase) -}}
+            {{- $delURL = printf "%s%s" $pkimmCurrentBase (strings.TrimPrefix .path $delURL) -}}
+          {{- end -}}
+        {{- end -}}
+      {{- end -}}
       {{- if and $delURL (strings.HasPrefix $delURL $base) -}}
         {{- $hasDelivLink = true -}}
         {{- $label := .menuTitle | default (.title | truncate 22 "…") -}}
@@ -145,15 +172,18 @@
     {{ end }}
 
     <a class="wg-nav-link" href="/blog/?wg={{ $wg.Params.wgID | lower }}">Blog</a>
-
-    {{ if eq ($wg.Params.wgID | upper) "PKIMM" }}
-    {{ partial "wg/pkimm-version-switcher.html" . }}
-    {{ end }}
   </div>
 </nav>
 {{/* Tree panels — one per deliverable section with child pages */}}
 {{- range $wg.Params.deliverables -}}
   {{- $delURL := .url | default "" -}}
+  {{- if and $isPkimm $pkimmCurrentBase $delURL -}}
+    {{- range $pkimmVersions -}}
+      {{- if and (strings.HasPrefix $delURL .path) (ne .path $pkimmCurrentBase) -}}
+        {{- $delURL = printf "%s%s" $pkimmCurrentBase (strings.TrimPrefix .path $delURL) -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
   {{- if and $delURL (strings.HasPrefix $delURL $base) -}}
     {{- $delSection := $.Site.GetPage $delURL -}}
     {{- if and $delSection (or $delSection.Sections $delSection.RegularPages) -}}
@@ -162,6 +192,9 @@
       {{- $treePage := cond $isActive $.Page $delSection -}}
 <div class="wg-nav-tree-panel wg-{{ $wg.Params.wgID | lower }}" id="wg-nav-tree-{{ $slug }}" hidden>
   {{ partial "wg/sidebar-tree.html" $treePage }}
+  {{ if eq ($wg.Params.wgID | upper) "PKIMM" }}
+  {{ partial "wg/pkimm-version-switcher.html" $.Page }}
+  {{ end }}
 </div>
     {{- end -}}
   {{- end -}}

--- a/layouts/wg/section.html
+++ b/layouts/wg/section.html
@@ -50,6 +50,23 @@
 {{- $resourcesPage   := .GetPage "resources" -}}
 {{- $confPage        := .GetPage "conferences" -}}
 {{- $charterPage     := .GetPage "charter" -}}
+{{/* PKIMM version awareness: on the WG landing page there is no "current
+     version", so $pkimmCurrentBase stays empty; the switcher still renders
+     in the Model tree panel with no active state. */}}
+{{- $isPkimm := eq $wgID "PKIMM" -}}
+{{- $pkimmVersions := slice -}}
+{{- $pkimmCurrentBase := "" -}}
+{{- if $isPkimm -}}
+  {{- $data := index $.Site.Data "pkimm-versions" -}}
+  {{- if and $data $data.versions -}}
+    {{- $pkimmVersions = $data.versions -}}
+    {{- range $pkimmVersions -}}
+      {{- if and (not $pkimmCurrentBase) (strings.HasPrefix $.Page.RelPermalink .path) -}}
+        {{- $pkimmCurrentBase = .path -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
 {{- if .Params.sectionNav -}}
 <nav class="wg-section-nav wg-{{ .Params.wgID | lower }}" id="wgSectionNav" aria-label="Page sections">
   <div class="container d-flex gap-1">
@@ -74,6 +91,13 @@
     {{- $hasDelivLink := false -}}
     {{- range .Params.deliverables -}}
       {{- $delURL := .url | default "" -}}
+      {{- if and $isPkimm $pkimmCurrentBase $delURL -}}
+        {{- range $pkimmVersions -}}
+          {{- if and (strings.HasPrefix $delURL .path) (ne .path $pkimmCurrentBase) -}}
+            {{- $delURL = printf "%s%s" $pkimmCurrentBase (strings.TrimPrefix .path $delURL) -}}
+          {{- end -}}
+        {{- end -}}
+      {{- end -}}
       {{- if and $delURL (strings.HasPrefix $delURL $base) -}}
         {{- $hasDelivLink = true -}}
         {{- $label := .menuTitle | default (.title | truncate 22 "…") -}}
@@ -132,6 +156,13 @@
 {{- $wgBase := .RelPermalink -}}
 {{- range .Params.deliverables -}}
   {{- $delURL := .url | default "" -}}
+  {{- if and $isPkimm $pkimmCurrentBase $delURL -}}
+    {{- range $pkimmVersions -}}
+      {{- if and (strings.HasPrefix $delURL .path) (ne .path $pkimmCurrentBase) -}}
+        {{- $delURL = printf "%s%s" $pkimmCurrentBase (strings.TrimPrefix .path $delURL) -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
   {{- if and $delURL (strings.HasPrefix $delURL $wgBase) -}}
     {{- $delPath := strings.TrimSuffix "/" (strings.TrimPrefix "/" $delURL) -}}
     {{- $delSection := $.Site.GetPage $delPath -}}
@@ -139,6 +170,9 @@
       {{- $slug := partial "wg/path-slug.html" (dict "path" $delURL) -}}
 <div class="wg-nav-tree-panel wg-{{ $.Page.Params.wgID | lower }}" id="wg-nav-tree-{{ $slug }}" hidden>
   {{ partial "wg/sidebar-tree.html" $delSection }}
+  {{ if $isPkimm }}
+  {{ partial "wg/pkimm-version-switcher.html" $.Page }}
+  {{ end }}
 </div>
     {{- end -}}
   {{- end -}}

--- a/layouts/wg/wg-content.html
+++ b/layouts/wg/wg-content.html
@@ -21,6 +21,21 @@
   {{- $confPage    = $wg.GetPage "conferences" -}}
   {{- $charterPage = $wg.GetPage "charter" -}}
 {{- end -}}
+{{/* PKIMM version awareness: see notes in layouts/partials/wg/sub-navigation.html */}}
+{{- $isPkimm := and $wg (eq ($wg.Params.wgID | upper) "PKIMM") -}}
+{{- $pkimmVersions := slice -}}
+{{- $pkimmCurrentBase := "" -}}
+{{- if $isPkimm -}}
+  {{- $data := index $.Site.Data "pkimm-versions" -}}
+  {{- if and $data $data.versions -}}
+    {{- $pkimmVersions = $data.versions -}}
+    {{- range $pkimmVersions -}}
+      {{- if and (not $pkimmCurrentBase) (strings.HasPrefix $.Page.RelPermalink .path) -}}
+        {{- $pkimmCurrentBase = .path -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
 
 {{/* ── Compact sub-page header ──────────────────────────────────────── */}}
 <div class="wg-sub-header wg-{{ $wg.Params.wgID | lower }}">
@@ -77,6 +92,13 @@
     {{- $hasDelivLink := false -}}
     {{- range $wg.Params.deliverables -}}
       {{- $delURL := .url | default "" -}}
+      {{- if and $isPkimm $pkimmCurrentBase $delURL -}}
+        {{- range $pkimmVersions -}}
+          {{- if and (strings.HasPrefix $delURL .path) (ne .path $pkimmCurrentBase) -}}
+            {{- $delURL = printf "%s%s" $pkimmCurrentBase (strings.TrimPrefix .path $delURL) -}}
+          {{- end -}}
+        {{- end -}}
+      {{- end -}}
       {{- if and $delURL (strings.HasPrefix $delURL $base) -}}
         {{- $hasDelivLink = true -}}
         {{- $label := .menuTitle | default (.title | truncate 22 "…") -}}
@@ -142,6 +164,13 @@
 {{/* Tree panels — one per deliverable section with child pages */}}
 {{- range $wg.Params.deliverables -}}
   {{- $delURL := .url | default "" -}}
+  {{- if and $isPkimm $pkimmCurrentBase $delURL -}}
+    {{- range $pkimmVersions -}}
+      {{- if and (strings.HasPrefix $delURL .path) (ne .path $pkimmCurrentBase) -}}
+        {{- $delURL = printf "%s%s" $pkimmCurrentBase (strings.TrimPrefix .path $delURL) -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
   {{- if and $delURL (strings.HasPrefix $delURL $base) -}}
     {{- $delSection := $.Site.GetPage $delURL -}}
     {{- if and $delSection (or $delSection.Sections $delSection.RegularPages) -}}
@@ -150,6 +179,9 @@
       {{- $treePage := cond $isActive $.Page $delSection -}}
 <div class="wg-nav-tree-panel wg-{{ $wg.Params.wgID | lower }}" id="wg-nav-tree-{{ $slug }}" hidden>
   {{ partial "wg/sidebar-tree.html" $treePage }}
+  {{ if $isPkimm }}
+  {{ partial "wg/pkimm-version-switcher.html" $.Page }}
+  {{ end }}
 </div>
     {{- end -}}
   {{- end -}}

--- a/layouts/wg/wg-sub.html
+++ b/layouts/wg/wg-sub.html
@@ -10,6 +10,21 @@
 {{- $base   := $wg.RelPermalink -}}
 {{- $sec    := .Params.wgSection -}}
 {{- $confPage := $wg.GetPage "conferences" -}}
+{{/* PKIMM version awareness: see notes in layouts/partials/wg/sub-navigation.html */}}
+{{- $isPkimm := eq $wgID "PKIMM" -}}
+{{- $pkimmVersions := slice -}}
+{{- $pkimmCurrentBase := "" -}}
+{{- if $isPkimm -}}
+  {{- $data := index $.Site.Data "pkimm-versions" -}}
+  {{- if and $data $data.versions -}}
+    {{- $pkimmVersions = $data.versions -}}
+    {{- range $pkimmVersions -}}
+      {{- if and (not $pkimmCurrentBase) (strings.HasPrefix $.Page.RelPermalink .path) -}}
+        {{- $pkimmCurrentBase = .path -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
 
 {{/* ── Compact sub-page header ──────────────────────────────────── */}}
 <div class="wg-sub-header wg-{{ $wg.Params.wgID | lower }}">
@@ -60,6 +75,13 @@
     {{- $hasDelivLink := false -}}
     {{- range $wg.Params.deliverables -}}
       {{- $delURL := .url | default "" -}}
+      {{- if and $isPkimm $pkimmCurrentBase $delURL -}}
+        {{- range $pkimmVersions -}}
+          {{- if and (strings.HasPrefix $delURL .path) (ne .path $pkimmCurrentBase) -}}
+            {{- $delURL = printf "%s%s" $pkimmCurrentBase (strings.TrimPrefix .path $delURL) -}}
+          {{- end -}}
+        {{- end -}}
+      {{- end -}}
       {{- if and $delURL (strings.HasPrefix $delURL $base) -}}
         {{- $hasDelivLink = true -}}
         {{- $label := .menuTitle | default (.title | truncate 22 "…") -}}
@@ -109,6 +131,13 @@
 {{/* Tree panels — one per deliverable section with child pages */}}
 {{- range $wg.Params.deliverables -}}
   {{- $delURL := .url | default "" -}}
+  {{- if and $isPkimm $pkimmCurrentBase $delURL -}}
+    {{- range $pkimmVersions -}}
+      {{- if and (strings.HasPrefix $delURL .path) (ne .path $pkimmCurrentBase) -}}
+        {{- $delURL = printf "%s%s" $pkimmCurrentBase (strings.TrimPrefix .path $delURL) -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
   {{- if and $delURL (strings.HasPrefix $delURL $base) -}}
     {{- $delSection := $.Site.GetPage $delURL -}}
     {{- if and $delSection (or $delSection.Sections $delSection.RegularPages) -}}
@@ -117,6 +146,9 @@
       {{- $treePage := cond $isActive $.Page $delSection -}}
 <div class="wg-nav-tree-panel wg-{{ $wg.Params.wgID | lower }}" id="wg-nav-tree-{{ $slug }}" hidden>
   {{ partial "wg/sidebar-tree.html" $treePage }}
+  {{ if $isPkimm }}
+  {{ partial "wg/pkimm-version-switcher.html" $.Page }}
+  {{ end }}
 </div>
     {{- end -}}
   {{- end -}}


### PR DESCRIPTION
Follow-up to #592.

- Move the inline `<script>` out of the partial into `assets/js/modules/global-ui.js` so the strict CSP no longer blocks it.
- Render the switcher inside the Model tree panel; drop the `position: fixed` menu and its JS positioning.
- Make the Model tab and tree panel follow the user's current version (so `/wg/pkimm/model/*` no longer shows the 1.0.0 tree).
- Apply the same in the other three WG layouts that render the section nav (`wg-sub.html`, `wg-content.html`, `section.html`), so the switcher shows up on Focus / Members / Resources / WG landing too.
- Resolve each version link's href at build time via `$.Site.GetPage`; when the equivalent sub-path doesn't exist in the target version, fall back to that version's overview with a small "Overview" hint instead of 404'ing.

Fix #595 