### PR TITLE
Add Kennedy Nwup as PKIMM vice chair

### DIFF
--- a/content/wg/pkimm/_index.md
+++ b/content/wg/pkimm/_index.md
@@ -28,6 +28,7 @@ cascade:
 
 chair:
   name: Roman Cinkais
+  viceChair: Kennedy Nwup
 
 keyDeliverables:
   - title: PKI Maturity Model


### PR DESCRIPTION
Aligns `content/wg/pkimm/_index.md` with the PKIMM charter, which already lists Kennedy Nwup (Afield) as vice chair. The WG landing page now renders the Vice Chair card alongside the Chair.