### PR TITLE
Don't force tag-pinned submodules to remote HEAD during prod build

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,4 @@
-import { spawn } from "node:child_process";
+import { execFileSync, spawn } from "node:child_process";
 import { readFileSync, writeFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { clearTimeout, setTimeout } from "node:timers";
@@ -60,7 +60,33 @@ async function buildHugoSite(isDev: boolean, rebuildFrontend = true): Promise<vo
   const cloudflareEnv = process.env.CLOUDFLARE_ENV ?? "local";
 
   if (!isDev && cloudflareEnv !== "local") {
-    await run("git", ["submodule", "update", "--init", "--remote"]);
+    // Clone any missing submodules at the SHAs recorded in the parent
+    // commit. Critically, no --remote here: tag-pinned snapshots like
+    // content/wg/pkimm/1.0.0 (no `branch=` in .gitmodules) must stay at
+    // their pinned SHA — passing --remote here would silently bump them
+    // to the remote HEAD branch (typically main) and override the pin.
+    await run("git", ["submodule", "update", "--init", "--recursive"]);
+    // Then refresh only the submodules that explicitly track a moving
+    // branch (have a `branch =` field in .gitmodules) to the latest tip.
+    // Mirrors the logic in scripts/build.sh.
+    const branchEntries = execFileSync(
+      "git",
+      ["config", "-f", ".gitmodules", "--name-only", "--get-regexp", "^submodule\\..*\\.branch$"],
+      { cwd: projectRoot, encoding: "utf8" },
+    )
+      .split("\n")
+      .filter(Boolean);
+    for (const entry of branchEntries) {
+      const name = entry.replace(/^submodule\./, "").replace(/\.branch$/, "");
+      const path = execFileSync(
+        "git",
+        ["config", "-f", ".gitmodules", "--get", `submodule.${name}.path`],
+        { cwd: projectRoot, encoding: "utf8" },
+      ).trim();
+      if (path) {
+        await run("git", ["submodule", "update", "--remote", "--", path]);
+      }
+    }
   }
 
   const hugoArgs = ["--destination", "public"];

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -69,13 +69,23 @@ async function buildHugoSite(isDev: boolean, rebuildFrontend = true): Promise<vo
     // Then refresh only the submodules that explicitly track a moving
     // branch (have a `branch =` field in .gitmodules) to the latest tip.
     // Mirrors the logic in scripts/build.sh.
-    const branchEntries = execFileSync(
-      "git",
-      ["config", "-f", ".gitmodules", "--name-only", "--get-regexp", "^submodule\\..*\\.branch$"],
-      { cwd: projectRoot, encoding: "utf8" },
-    )
-      .split("\n")
-      .filter(Boolean);
+    //
+    // `git config --get-regexp` exits 1 if there are no matches (or if
+    // .gitmodules is missing entirely), which would make execFileSync
+    // throw. Catch that so a repo with no branch-tracking submodules
+    // doesn't break the build.
+    let branchEntries: string[] = [];
+    try {
+      branchEntries = execFileSync(
+        "git",
+        ["config", "-f", ".gitmodules", "--name-only", "--get-regexp", "^submodule\\..*\\.branch$"],
+        { cwd: projectRoot, encoding: "utf8" },
+      )
+        .split("\n")
+        .filter(Boolean);
+    } catch {
+      // No branch-tracking submodules — nothing to refresh.
+    }
     for (const entry of branchEntries) {
       const name = entry.replace(/^submodule\./, "").replace(/\.branch$/, "");
       const path = execFileSync(


### PR DESCRIPTION
`vite.config.ts` runs `git submodule update --init --remote` on production builds. `--remote` updates every submodule to its remote-tracking branch's tip — including submodules without a `branch=` field in `.gitmodules`, which silently fall back to the remote's default branch (`main`).

That makes `content/wg/pkimm/1.0.0` (tag-pinned, no `branch=`, shares the `pkic/pkimm` repo with `content/wg/pkimm/model`) get bumped to `pkimm:main` on every production build, so https://pkic.org/wg/pkimm/1.0.0/ has been serving v1.1.0 content (e.g. `/wg/pkimm/1.0.0/categories/05-cryptography/` returns 200 — it shouldn't exist there).

`scripts/build.sh` already has the correct logic, but the prod build path goes through `vite.config.ts`. This change mirrors that logic: init at pinned SHAs first (no `--remote`), then refresh only the submodules that explicitly track a moving branch.

After deploy, `/wg/pkimm/1.0.0/` will start serving v1.0.0 content again automatically — the parent-repo SHA for the 1.0.0 submodule was always correct, just being overridden at build time.