### PR TITLE
Render PKIMM version switcher in the WG side menu

### DIFF
--- a/layouts/partials/wg/sidebar.html
+++ b/layouts/partials/wg/sidebar.html
@@ -13,4 +13,13 @@
 </button>
 <nav class="wg-sidebar" aria-label="Section navigation">
   {{- partial "wg/sidebar-tree.html" . -}}
+  {{- $wg := "" -}}
+  {{- range .Ancestors -}}
+    {{- if and (not $wg) .Params.wgID -}}
+      {{- $wg = . -}}
+    {{- end -}}
+  {{- end -}}
+  {{- if and $wg (eq ($wg.Params.wgID | upper) "PKIMM") -}}
+  {{ partial "wg/pkimm-version-switcher.html" . }}
+  {{- end -}}
 </nav>


### PR DESCRIPTION
The sidebar already calls the same `wg/sidebar-tree.html` partial used inside the top tree panel — adding the switcher right after it gives the two surfaces consistent content from a single source.

Gated to PKIMM by walking ancestors for `wgID`, same pattern as the surrounding layouts.

Close #595 