### PR TITLE
feat: Enable D1 read replication for admin dashboard endpoints

### DIFF
--- a/assets/ts/admin/api.ts
+++ b/assets/ts/admin/api.ts
@@ -4,7 +4,7 @@
  * Thin fetch wrapper that attaches the auth token from the global signal and
  * handles 401 responses by clearing auth (triggering a re-render to Login).
  */
-import { clearAuth, authToken } from "./state";
+import { clearAuth, authToken, saveAuthToken } from "./state";
 import { ApiClientError } from "../shared/api-client";
 import type { ApiErrorPayload } from "../shared/types";
 
@@ -21,6 +21,8 @@ export async function api<T = unknown>(path: string, opts?: ApiOpts): Promise<T>
     ...opts,
     headers: { ...headers, ...(opts?.headers ?? {}) },
   });
+  const nextToken = res.headers.get("x-admin-token");
+  if (nextToken) saveAuthToken(nextToken);
 
   const data: { error?: { message?: string; code?: string } } =
     res.status === 204 ? {} : await res.json().catch(() => ({}));

--- a/assets/ts/admin/sections/Users.tsx
+++ b/assets/ts/admin/sections/Users.tsx
@@ -3,7 +3,7 @@ import { Spinner } from "../../components/Spinner";
 import { ErrorAlert } from "../../components/ErrorAlert";
 import { ApiDataTable, type ApiTableActions } from "../../components/Table";
 import { api } from "../api";
-import { authToken } from "../state";
+import { authToken, saveAuthToken } from "../state";
 import { fmt, toast } from "../ui";
 import type { AdminUser } from "../types";
 import { confirmHeadshotUsage } from "../../shared/headshot/controller";
@@ -86,6 +86,8 @@ function UserDetailView({ userId, onBack }: { userId: string; onBack: () => void
     const token = authToken.value;
     if (token) headers["Authorization"] = `Bearer ${token}`;
     const res = await fetch(`/api/v1/admin/users/${uid}/headshot`, { method: "PUT", headers, body: file });
+    const nextToken = res.headers.get("x-admin-token");
+    if (nextToken) saveAuthToken(nextToken);
     const data = (await res.json().catch(() => ({}))) as { error?: { message?: string } };
     if (!res.ok) throw new Error(data.error?.message ?? `HTTP ${res.status}`);
   }

--- a/assets/ts/admin/sections/events/detail/ProposalDetailPage.tsx
+++ b/assets/ts/admin/sections/events/detail/ProposalDetailPage.tsx
@@ -6,7 +6,7 @@ import { ErrorAlert } from "../../../../components/ErrorAlert";
 import { DataTable } from "../../../../components/Table";
 import { Tabs } from "../../../../components/Tabs";
 import { api } from "../../../api";
-import { authToken, authEmail } from "../../../state";
+import { authToken, authEmail, saveAuthToken } from "../../../state";
 import { AdminHeadshotManager, ADMIN_HEADSHOT_DISCLAIMER } from "../../../../shared/headshot/AdminHeadshotManager";
 import { fmt, toast } from "../../../ui";
 import { useData } from "../../../../hooks/useData";
@@ -252,6 +252,8 @@ function SpeakerCard({
       headers,
       body: file,
     });
+    const nextToken = res.headers.get("x-admin-token");
+    if (nextToken) saveAuthToken(nextToken);
     const data = (await res.json().catch(() => ({}))) as {
       headshotUrl?: string;
       error?: { message?: string };

--- a/assets/ts/admin/state.ts
+++ b/assets/ts/admin/state.ts
@@ -14,10 +14,14 @@ export const isAuthed = computed(() => Boolean(authToken.value));
 export const eventList = signal<EventSummary[]>([]);
 export const currentEvent = signal<EventDetail | null>(null);
 
-export function saveAuth(token: string, email: string | null): void {
+export function saveAuthToken(token: string): void {
   authToken.value = token;
-  authEmail.value = email;
   localStorage.setItem("pkic_at", token);
+}
+
+export function saveAuth(token: string, email: string | null): void {
+  saveAuthToken(token);
+  authEmail.value = email;
   if (email) localStorage.setItem("pkic_ae", email);
 }
 

--- a/functions/_lib/auth/admin.ts
+++ b/functions/_lib/auth/admin.ts
@@ -21,11 +21,22 @@ interface AdminSessionRow {
   role: string;
 }
 
+const adminByRequest = new WeakMap<Request, AuthAdmin>();
+
+export function cacheAdminForRequest(request: Request, admin: AuthAdmin): void {
+  adminByRequest.set(request, admin);
+}
+
 export async function requireAdminFromRequest(
   db: DatabaseLike,
   request: Request,
   env?: Pick<Env, "ADMIN_API_KEY">,
 ): Promise<AuthAdmin> {
+  const cached = adminByRequest.get(request);
+  if (cached) {
+    return cached;
+  }
+
   const auth = request.headers.get("authorization") ?? "";
   const match = auth.match(/^Bearer\s+(.+)$/i);
   if (!match) {
@@ -36,10 +47,14 @@ export async function requireAdminFromRequest(
 
   // API key auth — no DB lookup needed, returns a synthetic admin identity
   if (env?.ADMIN_API_KEY && token === env.ADMIN_API_KEY) {
-    return { id: "api-key", email: "api-key", role: "admin" };
+    const admin = { id: "api-key", email: "api-key", role: "admin" };
+    cacheAdminForRequest(request, admin);
+    return admin;
   }
 
-  return getAdminBySessionToken(db, token);
+  const admin = await getAdminBySessionToken(db, token);
+  cacheAdminForRequest(request, admin);
+  return admin;
 }
 
 export async function getAdminBySessionToken(db: DatabaseLike, token: string): Promise<AuthAdmin> {

--- a/functions/_lib/auth/admin.ts
+++ b/functions/_lib/auth/admin.ts
@@ -3,6 +3,7 @@ import { first, run } from "../db/queries";
 import { normalizeEmail } from "../validation";
 import { nowIso, addMinutes, addHours } from "../utils/time";
 import { randomToken, sha256Hex } from "../utils/crypto";
+import { signJwt, verifyJwt, type JwtVerifyResult } from "../utils/jwt";
 import { uuid } from "../utils/ids";
 import type { AuthAdmin, DatabaseLike, Env } from "../types";
 
@@ -14,6 +15,7 @@ interface AdminUserRow {
 }
 
 interface AdminSessionRow {
+  id: string;
   user_id: string;
   expires_at: string;
   revoked_at: string | null;
@@ -21,16 +23,106 @@ interface AdminSessionRow {
   role: string;
 }
 
+export interface AdminSessionTokenClaims {
+  typ: "admin-session";
+  sub: string;
+  sid: string;
+  email: string;
+  role: string;
+  scopes: string[];
+  state?: string;
+  exp: number;
+}
+
+const ADMIN_SESSION_TOKEN_TYPE = "admin-session";
+
 const adminByRequest = new WeakMap<Request, AuthAdmin>();
+
+function constantTimeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) {
+    diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  return diff === 0;
+}
 
 export function cacheAdminForRequest(request: Request, admin: AuthAdmin): void {
   adminByRequest.set(request, admin);
 }
 
+export function getCachedAdminForRequest(request: Request): AuthAdmin | undefined {
+  return adminByRequest.get(request);
+}
+
+function sessionExpiresAtToExp(expiresAt: string): number {
+  const ms = new Date(expiresAt).getTime();
+  if (!Number.isFinite(ms)) {
+    throw new Error(`Invalid expiresAt timestamp: ${expiresAt}`);
+  }
+  return Math.floor(ms / 1000);
+}
+
+function isAdminSessionTokenClaims(claims: object): claims is AdminSessionTokenClaims {
+  const candidate = claims as Partial<AdminSessionTokenClaims>;
+  return (
+    candidate.typ === ADMIN_SESSION_TOKEN_TYPE &&
+    typeof candidate.sub === "string" &&
+    typeof candidate.sid === "string" &&
+    typeof candidate.email === "string" &&
+    typeof candidate.role === "string" &&
+    Array.isArray(candidate.scopes) &&
+    candidate.scopes.every((scope) => typeof scope === "string") &&
+    (candidate.state === undefined || typeof candidate.state === "string") &&
+    typeof candidate.exp === "number"
+  );
+}
+
+export async function signAdminSessionToken(
+  secret: string,
+  payload: {
+    admin: AuthAdmin;
+    sessionId: string;
+    expiresAt: string;
+    state?: string | null;
+    scopes?: string[];
+  },
+): Promise<string> {
+  const claims: AdminSessionTokenClaims = {
+    typ: ADMIN_SESSION_TOKEN_TYPE,
+    sub: payload.admin.id,
+    sid: payload.sessionId,
+    email: payload.admin.email,
+    role: payload.admin.role,
+    scopes: payload.scopes ?? payload.admin.scopes ?? [],
+    exp: sessionExpiresAtToExp(payload.expiresAt),
+  };
+
+  if (payload.state) {
+    claims.state = payload.state;
+  }
+
+  return signJwt(secret, claims as unknown as Record<string, unknown>);
+}
+
+export async function verifyAdminSessionToken(
+  secret: string,
+  token: string,
+): Promise<JwtVerifyResult<AdminSessionTokenClaims>> {
+  const result = await verifyJwt<object>(secret, token);
+  if (!result.ok) {
+    return result;
+  }
+  if (!isAdminSessionTokenClaims(result.claims)) {
+    return { ok: false, reason: "invalid" };
+  }
+  return { ok: true, claims: result.claims };
+}
+
 export async function requireAdminFromRequest(
   db: DatabaseLike,
   request: Request,
-  env?: Pick<Env, "ADMIN_API_KEY">,
+  env?: Pick<Env, "ADMIN_API_KEY" | "INTERNAL_SIGNING_SECRET">,
 ): Promise<AuthAdmin> {
   const cached = adminByRequest.get(request);
   if (cached) {
@@ -45,27 +137,40 @@ export async function requireAdminFromRequest(
 
   const token = match[1];
 
-  // API key auth — no DB lookup needed, returns a synthetic admin identity
-  if (env?.ADMIN_API_KEY && token === env.ADMIN_API_KEY) {
+  // API key auth — no DB lookup needed, returns a synthetic admin identity.
+  // Use constant-time comparison to avoid leaking the configured key via timing.
+  if (env?.ADMIN_API_KEY && constantTimeEqual(token, env.ADMIN_API_KEY)) {
     const admin = { id: "api-key", email: "api-key", role: "admin" };
     cacheAdminForRequest(request, admin);
     return admin;
   }
 
-  const admin = await getAdminBySessionToken(db, token);
+  if (!env?.INTERNAL_SIGNING_SECRET) {
+    throw new AppError(500, "INTERNAL_SECRET_MISSING", "INTERNAL_SIGNING_SECRET is not configured");
+  }
+
+  const verified = await verifyAdminSessionToken(env.INTERNAL_SIGNING_SECRET, token);
+  if (!verified.ok) {
+    throw new AppError(
+      401,
+      verified.reason === "expired" ? "AUTH_EXPIRED" : "AUTH_INVALID",
+      verified.reason === "expired" ? "Admin session expired" : "Invalid admin session token",
+    );
+  }
+
+  const admin = await getAdminBySessionClaims(db, verified.claims);
   cacheAdminForRequest(request, admin);
   return admin;
 }
 
-export async function getAdminBySessionToken(db: DatabaseLike, token: string): Promise<AuthAdmin> {
-  const tokenHash = await sha256Hex(token);
+export async function getAdminBySessionClaims(db: DatabaseLike, claims: AdminSessionTokenClaims): Promise<AuthAdmin> {
   const row = await first<AdminSessionRow>(
     db,
-    `SELECT s.user_id, s.expires_at, s.revoked_at, u.email, u.role
+    `SELECT s.id, s.user_id, s.expires_at, s.revoked_at, u.email, u.role
      FROM sessions s
      JOIN users u ON u.id = s.user_id
-     WHERE s.token_hash = ? AND u.active = 1 AND u.role = 'admin'`,
-    [tokenHash],
+     WHERE s.id = ? AND s.user_id = ? AND u.active = 1 AND u.role = 'admin'`,
+    [claims.sid, claims.sub],
   );
 
   if (!row) {
@@ -84,6 +189,10 @@ export async function getAdminBySessionToken(db: DatabaseLike, token: string): P
     id: row.user_id,
     email: row.email,
     role: row.role,
+    scopes: claims.scopes,
+    sessionId: row.id,
+    expiresAt: row.expires_at,
+    state: claims.state ?? null,
   };
 }
 
@@ -140,7 +249,7 @@ export async function requestAdminMagicLink(
 export async function verifyAdminMagicLink(
   db: DatabaseLike,
   payload: { token: string; sessionTtlHours: number; ipHash?: string | null; userAgentHash?: string | null },
-): Promise<{ admin: AuthAdmin; sessionToken: string; expiresAt: string }> {
+): Promise<{ admin: AuthAdmin; sessionId: string; expiresAt: string }> {
   const tokenHash = await sha256Hex(payload.token);
   const row = await first<{
     id: string;
@@ -180,17 +289,25 @@ export async function verifyAdminMagicLink(
     throw new AppError(403, "MAGIC_LINK_CONTEXT_MISMATCH", "Magic link is not valid from this browser");
   }
 
-  await run(db, "UPDATE auth_magic_links SET used_at = ? WHERE id = ?", [nowIso(), row.id]);
+  // Atomic consume to prevent TOCTOU race: only the request that flips used_at
+  // from NULL wins. Other concurrent verifications get MAGIC_LINK_USED.
+  const consume = await run(db, "UPDATE auth_magic_links SET used_at = ? WHERE id = ? AND used_at IS NULL", [
+    nowIso(),
+    row.id,
+  ]);
+  if (consume.changes === 0) {
+    throw new AppError(409, "MAGIC_LINK_USED", "Magic link already used");
+  }
 
-  const sessionToken = randomToken(24);
-  const sessionHash = await sha256Hex(sessionToken);
+  const sessionId = uuid();
+  const sessionHash = await sha256Hex(randomToken(24));
   const expiresAt = addHours(nowIso(), payload.sessionTtlHours);
 
   await run(
     db,
     `INSERT INTO sessions (id, user_id, token_hash, expires_at, revoked_at, created_at)
      VALUES (?, ?, ?, ?, NULL, ?)`,
-    [uuid(), row.user_id, sessionHash, expiresAt, nowIso()],
+    [sessionId, row.user_id, sessionHash, expiresAt, nowIso()],
   );
 
   return {
@@ -199,7 +316,7 @@ export async function verifyAdminMagicLink(
       email: row.email,
       role: row.role,
     },
-    sessionToken,
+    sessionId,
     expiresAt,
   };
 }

--- a/functions/_lib/db/context.ts
+++ b/functions/_lib/db/context.ts
@@ -1,0 +1,37 @@
+import type { DatabaseLike, Env } from "../types";
+
+export const REQUEST_DB_CONTEXT_KEY = "requestDb";
+
+export type RequestDbContext = {
+  Bindings: Env;
+  Variables: {
+    [REQUEST_DB_CONTEXT_KEY]?: DatabaseLike;
+  };
+};
+
+export interface AdminContext<P extends Record<string, string> = Record<string, string>> {
+  env: Env;
+  req: {
+    raw: Request;
+    param(name: string): string;
+    param(): P;
+    parseBody?: () => Promise<Record<string, unknown>>;
+  };
+  executionCtx: {
+    waitUntil(promise: Promise<unknown>): void;
+  };
+  var?: {
+    [REQUEST_DB_CONTEXT_KEY]?: DatabaseLike;
+  };
+  get?: (key: typeof REQUEST_DB_CONTEXT_KEY) => unknown;
+  set?: (key: typeof REQUEST_DB_CONTEXT_KEY, value: DatabaseLike) => void;
+}
+
+type RequestDbCarrier = Pick<AdminContext, "env"> &
+  Partial<Pick<AdminContext, "var">> & {
+    get?: (key: typeof REQUEST_DB_CONTEXT_KEY) => unknown;
+  };
+
+export function requestDb(c: RequestDbCarrier): DatabaseLike {
+  return c.var?.requestDb ?? (c.get?.(REQUEST_DB_CONTEXT_KEY) as DatabaseLike | undefined) ?? c.env.DB;
+}

--- a/functions/_lib/db/session.ts
+++ b/functions/_lib/db/session.ts
@@ -1,0 +1,19 @@
+import type { DatabaseLike } from "../types";
+
+type D1SessionConstraint = "first-primary" | "first-unconstrained";
+
+export type DatabaseSessionLike = DatabaseLike & {
+  getBookmark?(): string | null;
+};
+
+export function withD1Session(db: DatabaseLike, constraint: D1SessionConstraint): DatabaseSessionLike {
+  return db.withSession?.(constraint) ?? db;
+}
+
+export function readReplicaDb(db: DatabaseLike): DatabaseSessionLike {
+  return withD1Session(db, "first-unconstrained");
+}
+
+export function primaryFirstDb(db: DatabaseLike): DatabaseSessionLike {
+  return withD1Session(db, "first-primary");
+}

--- a/functions/_lib/db/session.ts
+++ b/functions/_lib/db/session.ts
@@ -10,8 +10,8 @@ export function withD1Session(db: DatabaseLike, constraint: D1SessionConstraint)
   return db.withSession?.(constraint) ?? db;
 }
 
-export function readReplicaDb(db: DatabaseLike): DatabaseSessionLike {
-  return withD1Session(db, "first-unconstrained");
+export function readReplicaDb(db: DatabaseLike, bookmark?: string | null): DatabaseSessionLike {
+  return db.withSession?.(bookmark || "first-unconstrained") ?? db;
 }
 
 export function primaryFirstDb(db: DatabaseLike): DatabaseSessionLike {

--- a/functions/_lib/types.ts
+++ b/functions/_lib/types.ts
@@ -148,4 +148,8 @@ export interface AuthAdmin {
   id: string;
   email: string;
   role: string;
+  scopes?: string[];
+  sessionId?: string;
+  expiresAt?: string;
+  state?: string | null;
 }

--- a/functions/_lib/types.ts
+++ b/functions/_lib/types.ts
@@ -11,6 +11,7 @@ export interface DatabaseLike {
   prepare(query: string): StatementLike;
   batch(statements: StatementLike[]): Promise<unknown[]>;
   exec?(query: string): Promise<unknown>;
+  withSession?(constraintOrBookmark?: string): DatabaseLike & { getBookmark?(): string | null };
 }
 
 export interface R2ObjectLike {

--- a/functions/_lib/utils/jwt.ts
+++ b/functions/_lib/utils/jwt.ts
@@ -1,17 +1,37 @@
 /**
  * Minimal HS256 JWT utility using the Web Crypto API (Workers-compatible).
- * Used for short-lived, self-contained admin manage tokens so no DB write is
- * needed — expiry, IP hash, and UA hash are claims inside the token itself.
+ * Used for signed admin tokens where tamper-proof claims need to travel through
+ * the client.
  */
 
 const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+function b64urlBytes(bytes: Uint8Array): string {
+  // Base64url-encode raw bytes (no UTF-8 transformation).
+  let binary = "";
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+function b64urlDecodeBytes(input: string): Uint8Array {
+  const binary = atob(input.replace(/-/g, "+").replace(/_/g, "/"));
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}
 
 function b64url(input: string): string {
-  return btoa(input).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+  // UTF-8 safe base64url for JSON strings.
+  return b64urlBytes(encoder.encode(input));
 }
 
 function b64urlDecode(input: string): string {
-  return atob(input.replace(/-/g, "+").replace(/_/g, "/"));
+  return decoder.decode(b64urlDecodeBytes(input));
 }
 
 async function hmacSign(secret: string, payload: string): Promise<string> {
@@ -19,7 +39,9 @@ async function hmacSign(secret: string, payload: string): Promise<string> {
     "sign",
   ]);
   const sig = await crypto.subtle.sign("HMAC", key, encoder.encode(payload));
-  return b64url(String.fromCharCode(...new Uint8Array(sig)));
+  // Raw signature bytes must be base64url'd directly — UTF-8 encoding them would
+  // mangle bytes >= 0x80 and produce non-standard JWT signatures.
+  return b64urlBytes(new Uint8Array(sig));
 }
 
 async function hmacVerify(secret: string, payload: string, signature: string): Promise<boolean> {
@@ -31,6 +53,43 @@ async function hmacVerify(secret: string, payload: string, signature: string): P
     diff |= expected.charCodeAt(i) ^ signature.charCodeAt(i);
   }
   return diff === 0;
+}
+
+export type JwtVerifyResult<TClaims> = { ok: true; claims: TClaims } | { ok: false; reason: "invalid" | "expired" };
+
+export async function signJwt(secret: string, claims: Record<string, unknown>): Promise<string> {
+  const header = b64url(JSON.stringify({ alg: "HS256", typ: "JWT" }));
+  const payload = b64url(JSON.stringify(claims));
+  const sig = await hmacSign(secret, `${header}.${payload}`);
+  return `${header}.${payload}.${sig}`;
+}
+
+export async function verifyJwt<TClaims extends object>(
+  secret: string,
+  token: string,
+): Promise<JwtVerifyResult<TClaims>> {
+  const parts = token.split(".");
+  if (parts.length !== 3) return { ok: false, reason: "invalid" };
+  const [header, payload, sig] = parts;
+  const valid = await hmacVerify(secret, `${header}.${payload}`, sig);
+  if (!valid) return { ok: false, reason: "invalid" };
+
+  let claims: TClaims;
+  try {
+    claims = JSON.parse(b64urlDecode(payload)) as TClaims;
+  } catch {
+    return { ok: false, reason: "invalid" };
+  }
+
+  const exp = (claims as Record<string, unknown>)["exp"];
+  if (!Number.isFinite(exp as number)) {
+    return { ok: false, reason: "invalid" };
+  }
+  if (typeof exp === "number" && Math.floor(Date.now() / 1000) > exp) {
+    return { ok: false, reason: "expired" };
+  }
+
+  return { ok: true, claims };
 }
 
 export interface AdminManageClaims {
@@ -50,39 +109,17 @@ export async function signAdminManageJwt(
   secret: string,
   claims: Omit<AdminManageClaims, "exp"> & { ttlSeconds: number },
 ): Promise<string> {
-  const header = b64url(JSON.stringify({ alg: "HS256", typ: "JWT" }));
-  const payload = b64url(
-    JSON.stringify({
-      sub: claims.sub,
-      event: claims.event,
-      iphash: claims.iphash,
-      uahash: claims.uahash,
-      exp: Math.floor(Date.now() / 1000) + claims.ttlSeconds,
-    }),
-  );
-  const sig = await hmacSign(secret, `${header}.${payload}`);
-  return `${header}.${payload}.${sig}`;
+  return signJwt(secret, {
+    sub: claims.sub,
+    event: claims.event,
+    iphash: claims.iphash,
+    uahash: claims.uahash,
+    exp: Math.floor(Date.now() / 1000) + claims.ttlSeconds,
+  });
 }
 
-export type JwtVerifyResult = { ok: true; claims: AdminManageClaims } | { ok: false; reason: "invalid" | "expired" };
+export type AdminManageJwtVerifyResult = JwtVerifyResult<AdminManageClaims>;
 
-export async function verifyAdminManageJwt(secret: string, token: string): Promise<JwtVerifyResult> {
-  const parts = token.split(".");
-  if (parts.length !== 3) return { ok: false, reason: "invalid" };
-  const [header, payload, sig] = parts;
-  const valid = await hmacVerify(secret, `${header}.${payload}`, sig);
-  if (!valid) return { ok: false, reason: "invalid" };
-
-  let claims: AdminManageClaims;
-  try {
-    claims = JSON.parse(b64urlDecode(payload)) as AdminManageClaims;
-  } catch {
-    return { ok: false, reason: "invalid" };
-  }
-
-  if (Math.floor(Date.now() / 1000) > claims.exp) {
-    return { ok: false, reason: "expired" };
-  }
-
-  return { ok: true, claims };
+export async function verifyAdminManageJwt(secret: string, token: string): Promise<AdminManageJwtVerifyResult> {
+  return verifyJwt<AdminManageClaims>(secret, token);
 }

--- a/functions/api/v1/admin/audit-log.ts
+++ b/functions/api/v1/admin/audit-log.ts
@@ -16,6 +16,7 @@ import { json } from "../../../_lib/http";
 import { requireAdminFromRequest } from "../../../_lib/auth/admin";
 import { all, first } from "../../../_lib/db/queries";
 import type { DatabaseLike } from "../../../_lib/types";
+import { requestDb, type AdminContext } from "../../../_lib/db/context";
 
 interface AuditLogRow {
   id: string;
@@ -71,8 +72,8 @@ function buildQuery(
   return { where, params };
 }
 
-export async function onRequestGet(c: any): Promise<Response> {
-  await requireAdminFromRequest(c.env.DB, c.req.raw, c.env);
+export async function onRequestGet(c: AdminContext): Promise<Response> {
+  await requireAdminFromRequest(requestDb(c), c.req.raw, c.env);
 
   const url = new URL(c.req.raw.url);
   const limit = Math.min(parseInt(url.searchParams.get("limit") ?? "50", 10) || 50, 200);
@@ -83,7 +84,7 @@ export async function onRequestGet(c: any): Promise<Response> {
   const action = (url.searchParams.get("action") ?? "").trim();
   const entityId = (url.searchParams.get("entityId") ?? "").trim();
 
-  const db: DatabaseLike = c.env.DB;
+  const db: DatabaseLike = requestDb(c);
   const { where, params } = buildQuery(q, entityType, actorType, action, entityId);
 
   const baseJoin = `FROM audit_log al LEFT JOIN users u ON al.actor_type = 'admin' AND u.id = al.actor_id`;

--- a/functions/api/v1/admin/auth/request-link.ts
+++ b/functions/api/v1/admin/auth/request-link.ts
@@ -8,8 +8,9 @@ import { processOutboxByIdBackground, queueEmail } from "../../../../_lib/email/
 import { writeAuditLog } from "../../../../_lib/services/audit";
 import { logInfo } from "../../../../_lib/logging";
 import { adminAuthRequestSchema } from "../../../../../assets/shared/schemas/api";
+import { requestDb, type AdminContext } from "../../../../_lib/db/context";
 
-export async function onRequestPost(c: any): Promise<Response> {
+export async function onRequestPost(c: AdminContext): Promise<Response> {
   const body = await parseJsonBody(c.req, adminAuthRequestSchema);
   const clientIp = getClientIp(c.req.raw);
   await enforceRateLimit({
@@ -30,7 +31,7 @@ export async function onRequestPost(c: any): Promise<Response> {
   const ipHash = await hashOptional(clientIp, secret);
   const userAgentHash = await hashOptional(getUserAgent(c.req.raw), secret);
 
-  const magic = await requestAdminMagicLink(c.env.DB, {
+  const magic = await requestAdminMagicLink(requestDb(c), {
     email: body.email,
     ipHash,
     userAgentHash,
@@ -39,7 +40,7 @@ export async function onRequestPost(c: any): Promise<Response> {
 
   if (magic.token && magic.admin) {
     const magicLinkUrl = `${appBaseUrl}/admin/?token=${encodeURIComponent(magic.token)}`;
-    const outboxId = await queueEmail(c.env.DB, {
+    const outboxId = await queueEmail(requestDb(c), {
       templateKey: "admin_magic_link",
       recipientEmail: magic.admin.email,
       recipientUserId: null,
@@ -53,11 +54,19 @@ export async function onRequestPost(c: any): Promise<Response> {
       },
     });
 
-    c.executionCtx.waitUntil(processOutboxByIdBackground(c.env.DB, c.env, outboxId));
+    c.executionCtx.waitUntil(processOutboxByIdBackground(requestDb(c), c.env, outboxId));
 
-    await writeAuditLog(c.env.DB, "admin", magic.admin.id, "admin_magic_link_requested", "admin_user", magic.admin.id, {
-      email: magic.admin.email,
-    });
+    await writeAuditLog(
+      requestDb(c),
+      "admin",
+      magic.admin.id,
+      "admin_magic_link_requested",
+      "admin_user",
+      magic.admin.id,
+      {
+        email: magic.admin.email,
+      },
+    );
   } else {
     logInfo("admin_magic_link_skipped", {
       reason:
@@ -70,7 +79,7 @@ export async function onRequestPost(c: any): Promise<Response> {
   return json({ success: true });
 }
 
-export async function onRequest(c: any): Promise<Response> {
+export async function onRequest(c: AdminContext): Promise<Response> {
   if (c.req.raw.method !== "POST") {
     return json({ error: { code: "METHOD_NOT_ALLOWED", message: "Method not allowed" } }, 405);
   }

--- a/functions/api/v1/admin/auth/router.ts
+++ b/functions/api/v1/admin/auth/router.ts
@@ -2,8 +2,9 @@ import { Hono } from "hono";
 import { fromHono } from "chanfana";
 import { onRequestPost as AdminAuthRequestLinkPost_l } from "./request-link";
 import { onRequestPost as AdminAuthVerifyLinkPost_l } from "./verify-link";
+import type { RequestDbContext } from "../../../../_lib/db/context";
 
-const app = new Hono();
+const app = new Hono<RequestDbContext>();
 export const openapi = fromHono(app);
 
 app.post("/request-link", AdminAuthRequestLinkPost_l);

--- a/functions/api/v1/admin/auth/verify-link.ts
+++ b/functions/api/v1/admin/auth/verify-link.ts
@@ -1,38 +1,56 @@
 import { parseJsonBody } from "../../../../_lib/validation";
 import { json } from "../../../../_lib/http";
-import { verifyAdminMagicLink } from "../../../../_lib/auth/admin";
+import { signAdminSessionToken, verifyAdminMagicLink } from "../../../../_lib/auth/admin";
 import { writeAuditLog } from "../../../../_lib/services/audit";
 import { getClientIp, getUserAgent, hashOptional, requireInternalSecret } from "../../../../_lib/request";
+import { enforceRateLimit } from "../../../../_lib/rate-limit";
 import { adminAuthVerifySchema } from "../../../../../assets/shared/schemas/api";
+import { requestDb, type AdminContext } from "../../../../_lib/db/context";
+import type { DatabaseSessionLike } from "../../../../_lib/db/session";
 
-export async function onRequestPost(c: any): Promise<Response> {
+export async function onRequestPost(c: AdminContext): Promise<Response> {
   const body = await parseJsonBody(c.req, adminAuthVerifySchema);
   const secret = requireInternalSecret(c.env);
+  const clientIp = getClientIp(c.req.raw);
+  // Defense-in-depth: rate-limit verification attempts per IP to limit token
+  // brute-force / context-probing even though tokens have high entropy.
+  await enforceRateLimit({
+    binding: c.env.IP_RATE_LIMITER,
+    namespace: "admin-auth-verify-link:ip",
+    key: clientIp,
+  });
+  const db = requestDb(c) as DatabaseSessionLike;
   const [ipHash, userAgentHash] = await Promise.all([
-    hashOptional(getClientIp(c.req.raw), secret),
+    hashOptional(clientIp, secret),
     hashOptional(getUserAgent(c.req.raw), secret),
   ]);
 
-  const verified = await verifyAdminMagicLink(c.env.DB, {
+  const verified = await verifyAdminMagicLink(db, {
     token: body.token,
     sessionTtlHours: 8,
     ipHash,
     userAgentHash,
   });
 
-  await writeAuditLog(c.env.DB, "admin", verified.admin.id, "admin_magic_link_verified", "admin_session", null, {
+  await writeAuditLog(db, "admin", verified.admin.id, "admin_magic_link_verified", "admin_session", null, {
     expiresAt: verified.expiresAt,
+  });
+  const token = await signAdminSessionToken(secret, {
+    admin: verified.admin,
+    sessionId: verified.sessionId,
+    expiresAt: verified.expiresAt,
+    state: db.getBookmark?.(),
   });
 
   return json({
     success: true,
-    token: verified.sessionToken,
+    token,
     expiresAt: verified.expiresAt,
     admin: verified.admin,
   });
 }
 
-export async function onRequest(c: any): Promise<Response> {
+export async function onRequest(c: AdminContext): Promise<Response> {
   if (c.req.raw.method !== "POST") {
     return json({ error: { code: "METHOD_NOT_ALLOWED", message: "Method not allowed" } }, 405);
   }

--- a/functions/api/v1/admin/donations.ts
+++ b/functions/api/v1/admin/donations.ts
@@ -11,6 +11,7 @@
 import { json } from "../../../_lib/http";
 import { requireAdminFromRequest } from "../../../_lib/auth/admin";
 import { all } from "../../../_lib/db/queries";
+import { requestDb, type AdminContext } from "../../../_lib/db/context";
 
 interface DonationRow {
   id: string;
@@ -37,8 +38,8 @@ interface StatusCount {
   count: number;
 }
 
-export async function onRequestGet(c: any): Promise<Response> {
-  await requireAdminFromRequest(c.env.DB, c.req.raw, c.env);
+export async function onRequestGet(c: AdminContext): Promise<Response> {
+  await requireAdminFromRequest(requestDb(c), c.req.raw, c.env);
 
   const url = new URL(c.req.raw.url);
   const status = url.searchParams.get("status") ?? "";
@@ -57,7 +58,7 @@ export async function onRequestGet(c: any): Promise<Response> {
 
   const [donations, counts, totalRow] = await Promise.all([
     all<DonationRow>(
-      c.env.DB,
+      requestDb(c),
       `SELECT id, checkout_session_id, payment_intent_id, name, email,
               organization, currency, gross_amount, net_amount, source,
               status, payment_method_type, session_expires_at,
@@ -69,8 +70,8 @@ export async function onRequestGet(c: any): Promise<Response> {
        LIMIT ? OFFSET ?`,
       [...params, limit, offset],
     ),
-    all<StatusCount>(c.env.DB, `SELECT status, COUNT(*) AS count FROM donations GROUP BY status`, []),
-    all<{ total: number }>(c.env.DB, `SELECT COUNT(*) AS total FROM donations ${where}`, [...params]),
+    all<StatusCount>(requestDb(c), `SELECT status, COUNT(*) AS count FROM donations GROUP BY status`, []),
+    all<{ total: number }>(requestDb(c), `SELECT COUNT(*) AS total FROM donations ${where}`, [...params]),
   ]);
 
   const summary = Object.fromEntries(counts.map((r) => [r.status, r.count]));
@@ -79,7 +80,7 @@ export async function onRequestGet(c: any): Promise<Response> {
   return json({ donations, summary, limit, offset, total });
 }
 
-export async function onRequest(c: any): Promise<Response> {
+export async function onRequest(c: AdminContext): Promise<Response> {
   if (c.req.raw.method !== "GET") {
     return json({ error: { code: "METHOD_NOT_ALLOWED", message: "Method not allowed" } }, 405);
   }

--- a/functions/api/v1/admin/donations/[id].ts
+++ b/functions/api/v1/admin/donations/[id].ts
@@ -6,21 +6,23 @@
 
 import { json } from "../../../../_lib/http";
 import { requireAdminFromRequest } from "../../../../_lib/auth/admin";
+import { requestDb, type AdminContext } from "../../../../_lib/db/context";
 
-export async function onRequestGet(c: any): Promise<Response> {
-  await requireAdminFromRequest(c.env.DB, c.req.raw, c.env);
+export async function onRequestGet(c: AdminContext): Promise<Response> {
+  await requireAdminFromRequest(requestDb(c), c.req.raw, c.env);
 
   const id = c.req.param("id");
   if (!id) return json({ error: { code: "BAD_REQUEST", message: "Missing donation id" } }, 400);
 
-  const row = await c.env.DB.prepare(
-    `SELECT id, checkout_session_id, payment_intent_id, name, email,
+  const row = await requestDb(c)
+    .prepare(
+      `SELECT id, checkout_session_id, payment_intent_id, name, email,
             organization, currency, gross_amount, net_amount, source,
             status, payment_method_type, session_expires_at,
             settled_amount, settled_currency,
             created_at, completed_at
      FROM donations WHERE id = ?`,
-  )
+    )
     .bind(id)
     .first();
 
@@ -29,7 +31,7 @@ export async function onRequestGet(c: any): Promise<Response> {
   return json({ donation: row });
 }
 
-export async function onRequest(c: any): Promise<Response> {
+export async function onRequest(c: AdminContext): Promise<Response> {
   if (c.req.raw.method !== "GET") {
     return json({ error: { code: "METHOD_NOT_ALLOWED", message: "Method not allowed" } }, 405);
   }

--- a/functions/api/v1/admin/donations/promoters.ts
+++ b/functions/api/v1/admin/donations/promoters.ts
@@ -8,6 +8,7 @@
 import { json } from "../../../../_lib/http";
 import { requireAdminFromRequest } from "../../../../_lib/auth/admin";
 import { all } from "../../../../_lib/db/queries";
+import { requestDb, type AdminContext } from "../../../../_lib/db/context";
 
 interface PromoterRow {
   code: string;
@@ -49,9 +50,9 @@ interface DominantCurrency {
   currency: string;
 }
 
-export async function onRequestGet(c: any): Promise<Response> {
-  await requireAdminFromRequest(c.env.DB, c.req.raw, c.env);
-  const db = c.env.DB;
+export async function onRequestGet(c: AdminContext): Promise<Response> {
+  await requireAdminFromRequest(requestDb(c), c.req.raw, c.env);
+  const db = requestDb(c);
 
   // Three simple queries instead of one complex CTE with window functions,
   // which causes CPU-budget issues in the D1 Workers binding.
@@ -128,7 +129,7 @@ export async function onRequestGet(c: any): Promise<Response> {
   return json({ promoters });
 }
 
-export async function onRequest(c: any): Promise<Response> {
+export async function onRequest(c: AdminContext): Promise<Response> {
   if (c.req.raw.method !== "GET") {
     return json({ error: { code: "METHOD_NOT_ALLOWED", message: "Method not allowed" } }, 405);
   }

--- a/functions/api/v1/admin/donations/router.ts
+++ b/functions/api/v1/admin/donations/router.ts
@@ -3,8 +3,9 @@ import { fromHono } from "chanfana";
 import { onRequestGet as AdminDonationsIdGet_l } from "./[id]";
 import { onRequestGet as AdminDonationsPromotersGet_l } from "./promoters";
 import { onRequestPost as AdminDonationsSyncPost_l } from "./sync";
+import type { RequestDbContext } from "../../../../_lib/db/context";
 
-const app = new Hono();
+const app = new Hono<RequestDbContext>();
 export const openapi = fromHono(app);
 
 app.get("/promoters", AdminDonationsPromotersGet_l);

--- a/functions/api/v1/admin/donations/sync.ts
+++ b/functions/api/v1/admin/donations/sync.ts
@@ -29,6 +29,8 @@ import { queueEmail, processOutboxByIdBackground } from "../../../../_lib/email/
 import { prerenderDonationBadge } from "../../../../_lib/services/og-badge-prerender";
 import { resolveAppBaseUrl } from "../../../../_lib/config";
 import { getOrCreatePromoterCode } from "../../donations/promoter";
+import { requestDb, type AdminContext } from "../../../../_lib/db/context";
+import type { DatabaseLike, Env } from "../../../../_lib/types";
 
 interface PendingDonation {
   id: string;
@@ -200,10 +202,10 @@ async function fetchPaymentDetails(stripeKey: string, paymentIntentId: string): 
 }
 
 async function sendPaymentFailedEmail(
-  db: D1Database,
-  env: any,
+  db: DatabaseLike,
+  env: Env,
   sessionId: string,
-  executionCtx: ExecutionContext,
+  executionCtx: Pick<ExecutionContext, "waitUntil">,
 ): Promise<void> {
   try {
     const donor = (await db
@@ -231,8 +233,8 @@ async function sendPaymentFailedEmail(
   }
 }
 
-export async function onRequestPost(c: any): Promise<Response> {
-  await requireAdminFromRequest(c.env.DB, c.req.raw, c.env);
+export async function onRequestPost(c: AdminContext): Promise<Response> {
+  await requireAdminFromRequest(requestDb(c), c.req.raw, c.env);
 
   const { env } = c;
 

--- a/functions/api/v1/admin/email-templates.ts
+++ b/functions/api/v1/admin/email-templates.ts
@@ -1,9 +1,10 @@
 import { json } from "../../../_lib/http";
 import { requireAdminFromRequest } from "../../../_lib/auth/admin";
 import { all, first } from "../../../_lib/db/queries";
+import { requestDb, type AdminContext } from "../../../_lib/db/context";
 
-export async function onRequestGet(c: any): Promise<Response> {
-  await requireAdminFromRequest(c.env.DB, c.req.raw, c.env);
+export async function onRequestGet(c: AdminContext): Promise<Response> {
+  await requireAdminFromRequest(requestDb(c), c.req.raw, c.env);
 
   const url = new URL(c.req.raw.url);
   const search = (url.searchParams.get("q") ?? "").trim();
@@ -26,7 +27,7 @@ export async function onRequestGet(c: any): Promise<Response> {
     version_count: number;
     draft_count: number;
   }>(
-    c.env.DB,
+    requestDb(c),
     `SELECT
        template_key,
        MAX(CASE WHEN status = 'active' THEN version END) AS active_version,
@@ -44,7 +45,7 @@ export async function onRequestGet(c: any): Promise<Response> {
   const templates = hasMore ? rows.slice(0, limit) : rows;
 
   const totalRow = await first<{ total: number }>(
-    c.env.DB,
+    requestDb(c),
     `SELECT COUNT(DISTINCT template_key) AS total FROM email_template_versions ${where}`,
     bindings,
   );
@@ -56,7 +57,7 @@ export async function onRequestGet(c: any): Promise<Response> {
   });
 }
 
-export async function onRequest(c: any): Promise<Response> {
+export async function onRequest(c: AdminContext): Promise<Response> {
   if (c.req.raw.method !== "GET") {
     return json({ error: { code: "METHOD_NOT_ALLOWED", message: "Method not allowed" } }, 405);
   }

--- a/functions/api/v1/admin/email-templates/[key]/activate.ts
+++ b/functions/api/v1/admin/email-templates/[key]/activate.ts
@@ -4,12 +4,13 @@ import { handleError, json } from "../../../../../_lib/http";
 import { requireAdminFromRequest } from "../../../../../_lib/auth/admin";
 import { activateTemplateVersion } from "../../../../../_lib/email/templates";
 import { adminEmailTemplateActivateSchema } from "../../../../../../assets/shared/schemas/api";
+import { requestDb, type AdminContext } from "../../../../../_lib/db/context";
 
-export async function onRequestPost(c: any): Promise<Response> {
-  await requireAdminFromRequest(c.env.DB, c.req.raw);
+export async function onRequestPost(c: AdminContext): Promise<Response> {
+  await requireAdminFromRequest(requestDb(c), c.req.raw, c.env);
   const body = await parseJsonBody(c.req, adminEmailTemplateActivateSchema);
 
-  await activateTemplateVersion(c.env.DB, {
+  await activateTemplateVersion(requestDb(c), {
     templateKey: c.req.param("key"),
     version: body.version,
   });
@@ -20,7 +21,7 @@ export async function onRequestPost(c: any): Promise<Response> {
 export class AdminEmailTemplatesKeyActivatePost extends OpenAPIRoute {
   schema = {};
 
-  async handle(c: any) {
+  async handle(c: AdminContext) {
     try {
       return await onRequestPost(c);
     } catch (error) {

--- a/functions/api/v1/admin/email-templates/[key]/exists.ts
+++ b/functions/api/v1/admin/email-templates/[key]/exists.ts
@@ -1,15 +1,16 @@
 import { json } from "../../../../../_lib/http";
 import { requireAdminFromRequest } from "../../../../../_lib/auth/admin";
 import { templateKeyExists } from "../../../../../_lib/email/templates";
+import { requestDb, type AdminContext } from "../../../../../_lib/db/context";
 
-export async function onRequestGet(c: any): Promise<Response> {
-  await requireAdminFromRequest(c.env.DB, c.req.raw);
+export async function onRequestGet(c: AdminContext): Promise<Response> {
+  await requireAdminFromRequest(requestDb(c), c.req.raw, c.env);
   const key = c.req.param("key");
-  const exists = await templateKeyExists(c.env.DB, key);
+  const exists = await templateKeyExists(requestDb(c), key);
   return json({ exists });
 }
 
-export async function onRequest(c: any): Promise<Response> {
+export async function onRequest(c: AdminContext): Promise<Response> {
   if (c.req.raw.method !== "GET") {
     return json({ error: { code: "METHOD_NOT_ALLOWED", message: "Method not allowed" } }, 405);
   }

--- a/functions/api/v1/admin/email-templates/[key]/router.ts
+++ b/functions/api/v1/admin/email-templates/[key]/router.ts
@@ -6,8 +6,9 @@ import {
   onRequestPost as AdminEmailTemplatesKeyVersionsPost_l,
 } from "./versions";
 import { onRequestGet as AdminEmailTemplatesKeyExistsGet_l } from "./exists";
+import type { RequestDbContext } from "../../../../../_lib/db/context";
 
-const app = new Hono();
+const app = new Hono<RequestDbContext>();
 export const openapi = fromHono(app);
 
 openapi.post("/activate", AdminEmailTemplatesKeyActivatePost);

--- a/functions/api/v1/admin/email-templates/[key]/versions.ts
+++ b/functions/api/v1/admin/email-templates/[key]/versions.ts
@@ -4,13 +4,14 @@ import { requireAdminFromRequest } from "../../../../../_lib/auth/admin";
 import { createTemplateVersion } from "../../../../../_lib/email/templates";
 import { all } from "../../../../../_lib/db/queries";
 import { adminEmailTemplateVersionSchema } from "../../../../../../assets/shared/schemas/api";
+import { requestDb, type AdminContext } from "../../../../../_lib/db/context";
 
-export async function onRequestGet(c: any): Promise<Response> {
-  await requireAdminFromRequest(c.env.DB, c.req.raw, c.env);
+export async function onRequestGet(c: AdminContext): Promise<Response> {
+  await requireAdminFromRequest(requestDb(c), c.req.raw, c.env);
   const key = c.req.param("key");
 
   const versions = await all(
-    c.env.DB,
+    requestDb(c),
     `SELECT * FROM email_template_versions
      WHERE template_key = ?
      ORDER BY version DESC`,
@@ -20,11 +21,11 @@ export async function onRequestGet(c: any): Promise<Response> {
   return json({ versions });
 }
 
-export async function onRequestPost(c: any): Promise<Response> {
-  const admin = await requireAdminFromRequest(c.env.DB, c.req.raw);
+export async function onRequestPost(c: AdminContext): Promise<Response> {
+  const admin = await requireAdminFromRequest(requestDb(c), c.req.raw, c.env);
   const body = await parseJsonBody(c.req, adminEmailTemplateVersionSchema);
 
-  const version = await createTemplateVersion(c.env.DB, {
+  const version = await createTemplateVersion(requestDb(c), {
     templateKey: c.req.param("key"),
     content: body.content,
     subjectTemplate: body.subjectTemplate,
@@ -35,7 +36,7 @@ export async function onRequestPost(c: any): Promise<Response> {
   return json({ success: true, version });
 }
 
-export async function onRequest(c: any): Promise<Response> {
+export async function onRequest(c: AdminContext): Promise<Response> {
   const method = c.req.raw.method;
   if (method === "GET") return onRequestGet(c);
   if (method === "POST") return onRequestPost(c);

--- a/functions/api/v1/admin/email-templates/preview.ts
+++ b/functions/api/v1/admin/email-templates/preview.ts
@@ -5,6 +5,7 @@ import { renderEmail, renderSubject } from "../../../../_lib/email/render";
 import { loadEmailLayout, loadEmailPartials } from "../../../../_lib/email/partials";
 import { resolveAppBaseUrl } from "../../../../_lib/config";
 import { adminEmailTemplatePreviewSchema } from "../../../../../assets/shared/schemas/api";
+import { requestDb, type AdminContext } from "../../../../_lib/db/context";
 
 function buildDefaultPreviewData(baseUrl: string): Record<string, unknown> {
   return {
@@ -30,8 +31,8 @@ function buildDefaultPreviewData(baseUrl: string): Record<string, unknown> {
   };
 }
 
-export async function onRequestPost(c: any): Promise<Response> {
-  await requireAdminFromRequest(c.env.DB, c.req.raw, c.env);
+export async function onRequestPost(c: AdminContext): Promise<Response> {
+  await requireAdminFromRequest(requestDb(c), c.req.raw, c.env);
   const body = await parseJsonBody(c.req, adminEmailTemplatePreviewSchema);
   const appBaseUrl = resolveAppBaseUrl(c.env, c.req.raw);
 
@@ -39,8 +40,8 @@ export async function onRequestPost(c: any): Promise<Response> {
     ...buildDefaultPreviewData(appBaseUrl),
     ...(body.data ?? {}),
   };
-  const partials = await loadEmailPartials(c.env.DB);
-  const layoutHtml = body.layoutHtml ?? (await loadEmailLayout(c.env.DB));
+  const partials = await loadEmailPartials(requestDb(c));
+  const layoutHtml = body.layoutHtml ?? (await loadEmailLayout(requestDb(c)));
   const dataWithPartials = { ...data, _partials: partials };
 
   const subject = renderSubject(body.subjectTemplate ?? null, "PKI Consortium Preview Subject", dataWithPartials);
@@ -56,7 +57,7 @@ export async function onRequestPost(c: any): Promise<Response> {
   });
 }
 
-export async function onRequest(c: any): Promise<Response> {
+export async function onRequest(c: AdminContext): Promise<Response> {
   if (c.req.raw.method !== "POST") {
     return json({ error: { code: "METHOD_NOT_ALLOWED", message: "Method not allowed" } }, 405);
   }

--- a/functions/api/v1/admin/email-templates/router.ts
+++ b/functions/api/v1/admin/email-templates/router.ts
@@ -2,8 +2,9 @@ import { Hono } from "hono";
 import { fromHono } from "chanfana";
 import { onRequestPost as AdminEmailTemplatesPreviewPost_l } from "./preview";
 import key_Router from "./[key]/router";
+import type { RequestDbContext } from "../../../../_lib/db/context";
 
-const app = new Hono();
+const app = new Hono<RequestDbContext>();
 export const openapi = fromHono(app);
 
 app.post("/preview", AdminEmailTemplatesPreviewPost_l);

--- a/functions/api/v1/admin/email/outbox.ts
+++ b/functions/api/v1/admin/email/outbox.ts
@@ -21,6 +21,7 @@ import { renderSubject } from "../../../../_lib/email/render";
 import { resolveTemplate } from "../../../../_lib/email/templates";
 import { json } from "../../../../_lib/http";
 import { parseJsonSafe } from "../../../../_lib/utils/json";
+import { requestDb, type AdminContext } from "../../../../_lib/db/context";
 interface OutboxListRow {
   id: string;
   event_id: string | null;
@@ -114,7 +115,7 @@ function buildWhereClause(
 }
 
 async function resolveSubjectTemplate(
-  c: any,
+  c: AdminContext,
   row: OutboxListRow,
   cache: Map<string, string | null>,
 ): Promise<string | null> {
@@ -125,7 +126,7 @@ async function resolveSubjectTemplate(
     }
 
     const versionRow = await first<TemplateSubjectRow>(
-      c.env.DB,
+      requestDb(c),
       "SELECT subject_template FROM email_template_versions WHERE template_key = ? AND version = ?",
       [row.template_key, row.template_version],
     );
@@ -140,7 +141,7 @@ async function resolveSubjectTemplate(
   }
 
   try {
-    const active = await resolveTemplate(c.env.DB, row.template_key);
+    const active = await resolveTemplate(requestDb(c), row.template_key);
     cache.set(cacheKey, active.subjectTemplate ?? null);
     return active.subjectTemplate ?? null;
   } catch {
@@ -150,7 +151,7 @@ async function resolveSubjectTemplate(
 }
 
 async function buildPreviewSubject(
-  c: any,
+  c: AdminContext,
   row: OutboxListRow,
   payload: Record<string, unknown>,
   cache: Map<string, string | null>,
@@ -167,8 +168,8 @@ async function buildPreviewSubject(
   return renderSubject(subjectTemplate, fallbackSubject, payload);
 }
 
-export async function onRequestGet(c: any): Promise<Response> {
-  await requireAdminFromRequest(c.env.DB, c.req.raw, c.env);
+export async function onRequestGet(c: AdminContext): Promise<Response> {
+  await requireAdminFromRequest(requestDb(c), c.req.raw, c.env);
 
   const url = new URL(c.req.raw.url);
   const status = (url.searchParams.get("status") ?? "").trim().toLowerCase();
@@ -182,7 +183,7 @@ export async function onRequestGet(c: any): Promise<Response> {
 
   const [rows, totalRow, statusCounts, messageTypeCounts, templateCounts, dueCounts, dueNextRow] = await Promise.all([
     all<OutboxListRow>(
-      c.env.DB,
+      requestDb(c),
       `SELECT
          o.id,
          o.event_id,
@@ -219,7 +220,7 @@ export async function onRequestGet(c: any): Promise<Response> {
       [...params, limit, offset],
     ),
     first<{ total: number }>(
-      c.env.DB,
+      requestDb(c),
       `SELECT COUNT(*) AS total
        FROM email_outbox o
        LEFT JOIN events e ON e.id = o.event_id
@@ -227,7 +228,7 @@ export async function onRequestGet(c: any): Promise<Response> {
       params,
     ),
     all<CountRow>(
-      c.env.DB,
+      requestDb(c),
       `SELECT o.status, COUNT(*) AS count
        FROM email_outbox o
        LEFT JOIN events e ON e.id = o.event_id
@@ -236,7 +237,7 @@ export async function onRequestGet(c: any): Promise<Response> {
       params,
     ),
     all<MessageTypeCountRow>(
-      c.env.DB,
+      requestDb(c),
       `SELECT o.message_type, COUNT(*) AS count
        FROM email_outbox o
        LEFT JOIN events e ON e.id = o.event_id
@@ -245,7 +246,7 @@ export async function onRequestGet(c: any): Promise<Response> {
       params,
     ),
     all<TemplateCountRow>(
-      c.env.DB,
+      requestDb(c),
       `SELECT o.template_key, COUNT(*) AS count
        FROM email_outbox o
        LEFT JOIN events e ON e.id = o.event_id
@@ -256,7 +257,7 @@ export async function onRequestGet(c: any): Promise<Response> {
       params,
     ),
     all<DueCountRow>(
-      c.env.DB,
+      requestDb(c),
       `SELECT status, COUNT(*) AS count
        FROM email_outbox
        WHERE status IN ('queued', 'retrying')
@@ -265,7 +266,7 @@ export async function onRequestGet(c: any): Promise<Response> {
       [new Date().toISOString()],
     ),
     first<{ send_after: string | null }>(
-      c.env.DB,
+      requestDb(c),
       `SELECT MIN(send_after) AS send_after
        FROM email_outbox
        WHERE status IN ('queued', 'retrying')`,
@@ -342,7 +343,7 @@ export async function onRequestGet(c: any): Promise<Response> {
 export class AdminEmailOutboxGet extends OpenAPIRoute {
   schema = {};
 
-  async handle(c: any) {
+  async handle(c: AdminContext) {
     return onRequestGet(c);
   }
 }

--- a/functions/api/v1/admin/email/router.ts
+++ b/functions/api/v1/admin/email/router.ts
@@ -1,8 +1,9 @@
 import { Hono } from "hono";
 import { fromHono } from "chanfana";
 import { AdminEmailOutboxGet } from "./outbox";
+import type { RequestDbContext } from "../../../../_lib/db/context";
 
-const app = new Hono();
+const app = new Hono<RequestDbContext>();
 export const openapi = fromHono(app);
 
 openapi.get("/outbox", AdminEmailOutboxGet);

--- a/functions/api/v1/admin/events.ts
+++ b/functions/api/v1/admin/events.ts
@@ -6,6 +6,7 @@ import { upsertEventFromHugo } from "../../../_lib/services/events";
 import { writeAuditLog } from "../../../_lib/services/audit";
 import { parseJsonSafe } from "../../../_lib/utils/json";
 import { adminCreateEventSchema } from "../../../../assets/shared/schemas/api";
+import { requestDb, type AdminContext } from "../../../_lib/db/context";
 
 interface EventWithStats {
   id: string;
@@ -32,11 +33,11 @@ interface EventWithStats {
  * Returns all events with aggregate registration and invite counts.
  * Supports both session-token auth and ADMIN_API_KEY.
  */
-export async function onRequestGet(c: any): Promise<Response> {
-  await requireAdminFromRequest(c.env.DB, c.req.raw, c.env);
+export async function onRequestGet(c: AdminContext): Promise<Response> {
+  await requireAdminFromRequest(requestDb(c), c.req.raw, c.env);
 
   const events = await all<EventWithStats>(
-    c.env.DB,
+    requestDb(c),
     `SELECT
        e.id,
        e.slug,
@@ -67,12 +68,12 @@ export async function onRequestGet(c: any): Promise<Response> {
  *
  * Creates a new event from the admin console. The slug must be unique.
  */
-export async function onRequestPost(c: any): Promise<Response> {
-  const admin = await requireAdminFromRequest(c.env.DB, c.req.raw, c.env);
+export async function onRequestPost(c: AdminContext): Promise<Response> {
+  const admin = await requireAdminFromRequest(requestDb(c), c.req.raw, c.env);
   const body = await parseJsonBody(c.req, adminCreateEventSchema);
 
   // Check slug uniqueness before upsert to give a clear error
-  const existing = await first<{ id: string }>(c.env.DB, "SELECT id FROM events WHERE slug = ?", [body.slug]);
+  const existing = await first<{ id: string }>(requestDb(c), "SELECT id FROM events WHERE slug = ?", [body.slug]);
   if (existing) {
     return json({ error: { code: "SLUG_TAKEN", message: `The slug '${body.slug}' is already in use` } }, 409);
   }
@@ -81,7 +82,7 @@ export async function onRequestPost(c: any): Promise<Response> {
   if (body.venue) settings["venue"] = body.venue;
   if (body.virtualUrl) settings["virtualUrl"] = body.virtualUrl;
 
-  const event = await upsertEventFromHugo(c.env.DB, {
+  const event = await upsertEventFromHugo(requestDb(c), {
     slug: body.slug,
     name: body.name,
     timezone: body.timezone,
@@ -92,7 +93,7 @@ export async function onRequestPost(c: any): Promise<Response> {
     settings,
   });
 
-  await writeAuditLog(c.env.DB, "admin", admin.id, "event_created", "event", event.id, { slug: event.slug });
+  await writeAuditLog(requestDb(c), "admin", admin.id, "event_created", "event", event.id, { slug: event.slug });
 
   return json(
     {
@@ -105,7 +106,7 @@ export async function onRequestPost(c: any): Promise<Response> {
   );
 }
 
-export async function onRequest(c: any): Promise<Response> {
+export async function onRequest(c: AdminContext): Promise<Response> {
   if (c.req.raw.method === "GET") return onRequestGet(c);
   if (c.req.raw.method === "POST") return onRequestPost(c);
   return json({ error: { code: "METHOD_NOT_ALLOWED", message: "Method not allowed" } }, 405);

--- a/functions/api/v1/admin/events/[eventSlug]/days.ts
+++ b/functions/api/v1/admin/events/[eventSlug]/days.ts
@@ -21,6 +21,7 @@ import { localDateTimeInTimeZoneToIso } from "../../../../../_lib/utils/timezone
 import { writeAuditLog } from "../../../../../_lib/services/audit";
 import type { DatabaseLike } from "../../../../../_lib/types";
 import { adminEventDaysReplaceSchema } from "../../../../../../assets/shared/schemas/api";
+import { requestDb, type AdminContext } from "../../../../../_lib/db/context";
 
 interface DayCountRow {
   event_day_id: string;
@@ -61,19 +62,19 @@ async function getDaysWithCounts(db: DatabaseLike, eventId: string) {
   }));
 }
 
-export async function onRequestGet(c: any): Promise<Response> {
-  await requireAdminFromRequest(c.env.DB, c.req.raw, c.env);
-  const event = await getEventBySlug(c.env.DB, c.req.param("eventSlug"));
-  const days = await getDaysWithCounts(c.env.DB, event.id);
+export async function onRequestGet(c: AdminContext): Promise<Response> {
+  await requireAdminFromRequest(requestDb(c), c.req.raw, c.env);
+  const event = await getEventBySlug(requestDb(c), c.req.param("eventSlug"));
+  const days = await getDaysWithCounts(requestDb(c), event.id);
   return json({ days });
 }
 
-export async function onRequestPut(c: any): Promise<Response> {
-  const admin = await requireAdminFromRequest(c.env.DB, c.req.raw, c.env);
+export async function onRequestPut(c: AdminContext): Promise<Response> {
+  const admin = await requireAdminFromRequest(requestDb(c), c.req.raw, c.env);
   const body = await parseJsonBody(c.req, adminEventDaysReplaceSchema);
-  const event = await getEventBySlug(c.env.DB, c.req.param("eventSlug"));
+  const event = await getEventBySlug(requestDb(c), c.req.param("eventSlug"));
 
-  const existing = await listEventDays(c.env.DB, event.id);
+  const existing = await listEventDays(requestDb(c), event.id);
   const existingByDate = new Map(existing.map((d) => [d.day_date, d]));
   const incomingDates = new Set(body.days.map((d) => d.date));
 
@@ -84,14 +85,14 @@ export async function onRequestPut(c: any): Promise<Response> {
   for (const day of existing) {
     if (!incomingDates.has(day.day_date)) {
       const reg = await first<{ n: number }>(
-        c.env.DB,
+        requestDb(c),
         "SELECT COUNT(*) AS n FROM registration_day_attendance WHERE event_day_id = ?",
         [day.id],
       );
       if ((reg?.n ?? 0) > 0) {
         skipped.push(day.day_date);
       } else {
-        await run(c.env.DB, "DELETE FROM event_days WHERE id = ?", [day.id]);
+        await run(requestDb(c), "DELETE FROM event_days WHERE id = ?", [day.id]);
       }
     }
   }
@@ -120,7 +121,7 @@ export async function onRequestPut(c: any): Promise<Response> {
     const existing_day = existingByDate.get(day.date);
     if (existing_day) {
       await run(
-        c.env.DB,
+        requestDb(c),
         `UPDATE event_days
          SET label = ?, starts_at = ?, ends_at = ?, in_person_capacity = ?, attendance_options_json = ?, sort_order = ?, updated_at = ?
          WHERE id = ?`,
@@ -128,7 +129,7 @@ export async function onRequestPut(c: any): Promise<Response> {
       );
     } else {
       await run(
-        c.env.DB,
+        requestDb(c),
         `INSERT INTO event_days
            (id, event_id, day_date, label, starts_at, ends_at, in_person_capacity, attendance_options_json, sort_order, created_at, updated_at)
          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
@@ -137,16 +138,16 @@ export async function onRequestPut(c: any): Promise<Response> {
     }
   }
 
-  await writeAuditLog(c.env.DB, "admin", admin.id, "event_days_updated", "event", event.id, {
+  await writeAuditLog(requestDb(c), "admin", admin.id, "event_days_updated", "event", event.id, {
     dayCount: body.days.length,
     skipped,
   });
 
-  const updatedDays = await getDaysWithCounts(c.env.DB, event.id);
+  const updatedDays = await getDaysWithCounts(requestDb(c), event.id);
   return json({ success: true, days: updatedDays, skipped });
 }
 
-export async function onRequest(c: any): Promise<Response> {
+export async function onRequest(c: AdminContext): Promise<Response> {
   if (c.req.raw.method === "GET") return onRequestGet(c);
   if (c.req.raw.method === "PUT") return onRequestPut(c);
   return json({ error: { code: "METHOD_NOT_ALLOWED", message: "Method not allowed" } }, 405);

--- a/functions/api/v1/admin/events/[eventSlug]/emails/campaign/preview.ts
+++ b/functions/api/v1/admin/events/[eventSlug]/emails/campaign/preview.ts
@@ -18,17 +18,18 @@ import {
   signCampaignPreviewToken,
 } from "../../../../../../../_lib/services/admin-email-campaign";
 import { adminEventCampaignPreviewSchema } from "../../../../../../../../assets/shared/schemas/api";
+import { requestDb, type AdminContext } from "../../../../../../../_lib/db/context";
 
 const PREVIEW_TTL_SECONDS = 10 * 60;
 
-export async function onRequestPost(c: any): Promise<Response> {
-  const admin = await requireAdminFromRequest(c.env.DB, c.req.raw, c.env);
+export async function onRequestPost(c: AdminContext): Promise<Response> {
+  const admin = await requireAdminFromRequest(requestDb(c), c.req.raw, c.env);
   const body = await parseJsonBody(c.req, adminEventCampaignPreviewSchema);
-  const event = await getEventBySlug(c.env.DB, c.req.param("eventSlug"));
+  const event = await getEventBySlug(requestDb(c), c.req.param("eventSlug"));
   const secret = requireInternalSecret(c.env);
   const appBaseUrl = resolveAppBaseUrl(c.env, c.req.raw);
 
-  const recipients = await listCampaignRecipients(c.env.DB, event.id, {
+  const recipients = await listCampaignRecipients(requestDb(c), event.id, {
     audience: body.filter.audience,
     attendeeStatus: body.filter.attendeeStatus,
     attendanceType: body.filter.attendanceType,
@@ -84,7 +85,8 @@ export async function onRequestPost(c: any): Promise<Response> {
   }
 
   if (body.sendMode === "bcc_batch") {
-    const template = !body.bodyContent && body.templateKey ? await resolveTemplate(c.env.DB, body.templateKey) : null;
+    const template =
+      !body.bodyContent && body.templateKey ? await resolveTemplate(requestDb(c), body.templateKey) : null;
     const unsafeRefs = findBroadcastOnlyTemplateRefs(uniqueRecipients, [
       body.subjectOverride,
       body.bodyContent,
@@ -103,8 +105,8 @@ export async function onRequestPost(c: any): Promise<Response> {
 
   let subject: string;
   let rendered: { html: string; text: string };
-  const partials = await loadEmailPartials(c.env.DB);
-  const layoutHtml = await loadEmailLayout(c.env.DB);
+  const partials = await loadEmailPartials(requestDb(c));
+  const layoutHtml = await loadEmailLayout(requestDb(c));
   const sample = uniqueRecipients[0];
   const routeVars =
     body.filter.audience === "attendees"
@@ -127,7 +129,7 @@ export async function onRequestPost(c: any): Promise<Response> {
     subject = renderSubject(body.subjectOverride ?? null, `Update: ${event.name}`, dataWithPartials);
     rendered = await renderEmail(body.bodyContent, dataWithPartials, layoutHtml, "markdown", appBaseUrl);
   } else {
-    const template = await resolveTemplate(c.env.DB, body.templateKey as string);
+    const template = await resolveTemplate(requestDb(c), body.templateKey as string);
     const data = {
       ...sampleData,
       customText: body.customText ?? "",
@@ -159,7 +161,7 @@ export async function onRequestPost(c: any): Promise<Response> {
   });
 }
 
-export async function onRequest(c: any): Promise<Response> {
+export async function onRequest(c: AdminContext): Promise<Response> {
   if (c.req.raw.method !== "POST") {
     return json({ error: { code: "METHOD_NOT_ALLOWED", message: "Method not allowed" } }, 405);
   }

--- a/functions/api/v1/admin/events/[eventSlug]/emails/campaign/router.ts
+++ b/functions/api/v1/admin/events/[eventSlug]/emails/campaign/router.ts
@@ -2,8 +2,9 @@ import { Hono } from "hono";
 import { fromHono } from "chanfana";
 import { onRequestPost as AdminEventsEventSlugEmailsCampaignPreviewPost_l } from "./preview";
 import { onRequestPost as AdminEventsEventSlugEmailsCampaignSendPost_l } from "./send";
+import type { RequestDbContext } from "../../../../../../../_lib/db/context";
 
-const app = new Hono();
+const app = new Hono<RequestDbContext>();
 export const openapi = fromHono(app);
 
 app.post("/preview", AdminEventsEventSlugEmailsCampaignPreviewPost_l);

--- a/functions/api/v1/admin/events/[eventSlug]/emails/campaign/send.ts
+++ b/functions/api/v1/admin/events/[eventSlug]/emails/campaign/send.ts
@@ -16,15 +16,16 @@ import {
   verifyCampaignPreviewToken,
 } from "../../../../../../../_lib/services/admin-email-campaign";
 import { adminEventCampaignSendSchema } from "../../../../../../../../assets/shared/schemas/api";
+import { requestDb, type AdminContext } from "../../../../../../../_lib/db/context";
 
-export async function onRequestPost(c: any): Promise<Response> {
-  const admin = await requireAdminFromRequest(c.env.DB, c.req.raw, c.env);
+export async function onRequestPost(c: AdminContext): Promise<Response> {
+  const admin = await requireAdminFromRequest(requestDb(c), c.req.raw, c.env);
   const body = await parseJsonBody(c.req, adminEventCampaignSendSchema);
-  const event = await getEventBySlug(c.env.DB, c.req.param("eventSlug"));
+  const event = await getEventBySlug(requestDb(c), c.req.param("eventSlug"));
   const secret = requireInternalSecret(c.env);
   const appBaseUrl = resolveAppBaseUrl(c.env, c.req.raw);
 
-  const recipients = await listCampaignRecipients(c.env.DB, event.id, {
+  const recipients = await listCampaignRecipients(requestDb(c), event.id, {
     audience: body.filter.audience,
     attendeeStatus: body.filter.attendeeStatus,
     attendanceType: body.filter.attendanceType,
@@ -89,7 +90,7 @@ export async function onRequestPost(c: any): Promise<Response> {
 
   // Validate template exists only when not using a direct body override
   const templateKey = body.bodyContent ? body.templateKey || "__direct__" : (body.templateKey as string);
-  const template = !body.bodyContent ? await resolveTemplate(c.env.DB, templateKey) : null;
+  const template = !body.bodyContent ? await resolveTemplate(requestDb(c), templateKey) : null;
 
   if (body.sendMode === "bcc_batch") {
     const unsafeRefs = findBroadcastOnlyTemplateRefs(uniqueRecipients, [
@@ -117,7 +118,7 @@ export async function onRequestPost(c: any): Promise<Response> {
 
   if (body.sendMode === "personal") {
     for (const recipient of uniqueRecipients) {
-      const outboxId = await queueEmail(c.env.DB, {
+      const outboxId = await queueEmail(requestDb(c), {
         eventId: event.id,
         templateKey,
         recipientEmail: recipient.email,
@@ -135,7 +136,7 @@ export async function onRequestPost(c: any): Promise<Response> {
         },
       });
       queued += 1;
-      c.executionCtx.waitUntil(processOutboxByIdBackground(c.env.DB, c.env, outboxId));
+      c.executionCtx.waitUntil(processOutboxByIdBackground(requestDb(c), c.env, outboxId));
     }
     batches = uniqueRecipients.length;
   } else {
@@ -144,7 +145,7 @@ export async function onRequestPost(c: any): Promise<Response> {
       const to = chunk[0];
       if (!to) continue;
       const bcc = chunk.slice(1).map((recipient) => recipient.email);
-      const outboxId = await queueEmail(c.env.DB, {
+      const outboxId = await queueEmail(requestDb(c), {
         eventId: event.id,
         templateKey,
         recipientEmail: to.email,
@@ -163,7 +164,7 @@ export async function onRequestPost(c: any): Promise<Response> {
       });
       queued += chunk.length;
       batches += 1;
-      c.executionCtx.waitUntil(processOutboxByIdBackground(c.env.DB, c.env, outboxId));
+      c.executionCtx.waitUntil(processOutboxByIdBackground(requestDb(c), c.env, outboxId));
     }
   }
 
@@ -175,7 +176,7 @@ export async function onRequestPost(c: any): Promise<Response> {
   });
 }
 
-export async function onRequest(c: any): Promise<Response> {
+export async function onRequest(c: AdminContext): Promise<Response> {
   if (c.req.raw.method !== "POST") {
     return json({ error: { code: "METHOD_NOT_ALLOWED", message: "Method not allowed" } }, 405);
   }

--- a/functions/api/v1/admin/events/[eventSlug]/emails/router.ts
+++ b/functions/api/v1/admin/events/[eventSlug]/emails/router.ts
@@ -1,8 +1,9 @@
 import { Hono } from "hono";
 import { fromHono } from "chanfana";
 import campaign_Router from "./campaign/router";
+import type { RequestDbContext } from "../../../../../../_lib/db/context";
 
-const app = new Hono();
+const app = new Hono<RequestDbContext>();
 export const openapi = fromHono(app);
 
 app.route("/campaign", campaign_Router);

--- a/functions/api/v1/admin/events/[eventSlug]/forms.ts
+++ b/functions/api/v1/admin/events/[eventSlug]/forms.ts
@@ -16,6 +16,7 @@ import { uuid } from "../../../../../_lib/utils/ids";
 import { stringifyJson } from "../../../../../_lib/utils/json";
 import { writeAuditLog } from "../../../../../_lib/services/audit";
 import { adminFormCreateSchema } from "../../../../../../assets/shared/schemas/api";
+import { requestDb, type AdminContext } from "../../../../../_lib/db/context";
 
 interface FormRow {
   id: string;
@@ -32,12 +33,12 @@ interface FormRow {
   submission_count: number;
 }
 
-export async function onRequestGet(c: any): Promise<Response> {
-  await requireAdminFromRequest(c.env.DB, c.req.raw, c.env);
-  const event = await getEventBySlug(c.env.DB, c.req.param("eventSlug"));
+export async function onRequestGet(c: AdminContext): Promise<Response> {
+  await requireAdminFromRequest(requestDb(c), c.req.raw, c.env);
+  const event = await getEventBySlug(requestDb(c), c.req.param("eventSlug"));
 
   const forms = await all<FormRow>(
-    c.env.DB,
+    requestDb(c),
     `SELECT
        f.*,
        COUNT(DISTINCT ff.id) AS field_count,
@@ -55,16 +56,16 @@ export async function onRequestGet(c: any): Promise<Response> {
   return json({ forms });
 }
 
-export async function onRequestPost(c: any): Promise<Response> {
-  const admin = await requireAdminFromRequest(c.env.DB, c.req.raw, c.env);
+export async function onRequestPost(c: AdminContext): Promise<Response> {
+  const admin = await requireAdminFromRequest(requestDb(c), c.req.raw, c.env);
   const body = await parseJsonBody(c.req, adminFormCreateSchema);
-  const event = await getEventBySlug(c.env.DB, c.req.param("eventSlug"));
+  const event = await getEventBySlug(requestDb(c), c.req.param("eventSlug"));
 
   const now = nowIso();
   const formId = uuid();
 
   await run(
-    c.env.DB,
+    requestDb(c),
     `INSERT INTO forms (id, key, scope_type, scope_ref, purpose, status, title, description, created_at, updated_at)
      VALUES (?, ?, 'event', ?, ?, ?, ?, ?, ?, ?)`,
     [formId, body.key, event.id, body.purpose, body.status, body.title, body.description ?? null, now, now],
@@ -72,7 +73,7 @@ export async function onRequestPost(c: any): Promise<Response> {
 
   for (const field of body.fields) {
     await run(
-      c.env.DB,
+      requestDb(c),
       `INSERT INTO form_fields (id, form_id, key, label, field_type, required, options_json, validation_json, sort_order, created_at)
        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       [
@@ -90,7 +91,7 @@ export async function onRequestPost(c: any): Promise<Response> {
     );
   }
 
-  await writeAuditLog(c.env.DB, "admin", admin.id, "event_form_created", "form", formId, {
+  await writeAuditLog(requestDb(c), "admin", admin.id, "event_form_created", "form", formId, {
     eventSlug: event.slug,
     key: body.key,
     purpose: body.purpose,
@@ -99,7 +100,7 @@ export async function onRequestPost(c: any): Promise<Response> {
   return json({ success: true, formId, key: body.key }, 201);
 }
 
-export async function onRequest(c: any): Promise<Response> {
+export async function onRequest(c: AdminContext): Promise<Response> {
   if (c.req.raw.method === "GET") return onRequestGet(c);
   if (c.req.raw.method === "POST") return onRequestPost(c);
   return json({ error: { code: "METHOD_NOT_ALLOWED", message: "Method not allowed" } }, 405);

--- a/functions/api/v1/admin/events/[eventSlug]/index.ts
+++ b/functions/api/v1/admin/events/[eventSlug]/index.ts
@@ -9,17 +9,18 @@ import { requireAdminFromRequest } from "../../../../../_lib/auth/admin";
 import { getEventBySlug } from "../../../../../_lib/services/events";
 import { first } from "../../../../../_lib/db/queries";
 import { parseJsonSafe } from "../../../../../_lib/utils/json";
+import { requestDb, type AdminContext } from "../../../../../_lib/db/context";
 
 interface RetentionPolicyRow {
   user_retention_days: number;
 }
 
-export async function onRequestGet(c: any): Promise<Response> {
-  await requireAdminFromRequest(c.env.DB, c.req.raw, c.env);
-  const event = await getEventBySlug(c.env.DB, c.req.param("eventSlug"));
+export async function onRequestGet(c: AdminContext): Promise<Response> {
+  await requireAdminFromRequest(requestDb(c), c.req.raw, c.env);
+  const event = await getEventBySlug(requestDb(c), c.req.param("eventSlug"));
 
   const retention = await first<RetentionPolicyRow>(
-    c.env.DB,
+    requestDb(c),
     "SELECT user_retention_days FROM retention_policies WHERE event_id = ?",
     [event.id],
   );
@@ -48,7 +49,7 @@ export async function onRequestGet(c: any): Promise<Response> {
   });
 }
 
-export async function onRequest(c: any): Promise<Response> {
+export async function onRequest(c: AdminContext): Promise<Response> {
   if (c.req.raw.method !== "GET") {
     return json({ error: { code: "METHOD_NOT_ALLOWED", message: "Method not allowed" } }, 405);
   }

--- a/functions/api/v1/admin/events/[eventSlug]/invites/[inviteId]/resend.ts
+++ b/functions/api/v1/admin/events/[eventSlug]/invites/[inviteId]/resend.ts
@@ -12,6 +12,7 @@ import {
 } from "../../../../../../../_lib/services/frontend-links";
 import { refreshInviteToken } from "../../../../../../../_lib/services/invites";
 import { nowIso } from "../../../../../../../_lib/utils/time";
+import { requestDb, type AdminContext } from "../../../../../../../_lib/db/context";
 
 type InviteRow = {
   id: string;
@@ -24,12 +25,12 @@ type InviteRow = {
   created_at: string;
 };
 
-export async function onRequestPost(c: any): Promise<Response> {
-  await requireAdminFromRequest(c.env.DB, c.req.raw, c.env);
+export async function onRequestPost(c: AdminContext): Promise<Response> {
+  await requireAdminFromRequest(requestDb(c), c.req.raw, c.env);
 
-  const event = await getEventBySlug(c.env.DB, c.req.param("eventSlug"));
+  const event = await getEventBySlug(requestDb(c), c.req.param("eventSlug"));
   const invite = await first<InviteRow>(
-    c.env.DB,
+    requestDb(c),
     `SELECT
        id,
        event_id,
@@ -58,12 +59,12 @@ export async function onRequestPost(c: any): Promise<Response> {
   }
 
   const appBaseUrl = resolveAppBaseUrl(c.env, c.req.raw);
-  const token = await refreshInviteToken(c.env.DB, invite.id);
+  const token = await refreshInviteToken(requestDb(c), invite.id);
   const declineUrl = inviteDeclineUrl(appBaseUrl, event, token);
 
   const now = nowIso();
   await run(
-    c.env.DB,
+    requestDb(c),
     `UPDATE invites
      SET
        status = 'sent',
@@ -84,7 +85,7 @@ export async function onRequestPost(c: any): Promise<Response> {
   const templateKey = invite.invite_type === "attendee" ? "attendee_invite" : "speaker_invite";
   const subject = invite.invite_type === "attendee" ? `Invitation: ${event.name}` : `Speaker invitation: ${event.name}`;
 
-  const outboxId = await queueEmail(c.env.DB, {
+  const outboxId = await queueEmail(requestDb(c), {
     eventId: event.id,
     templateKey,
     recipientEmail: invite.invitee_email,
@@ -102,12 +103,12 @@ export async function onRequestPost(c: any): Promise<Response> {
     },
   });
 
-  c.executionCtx.waitUntil(processOutboxByIdBackground(c.env.DB, c.env, outboxId));
+  c.executionCtx.waitUntil(processOutboxByIdBackground(requestDb(c), c.env, outboxId));
 
   return json({ success: true, inviteId: invite.id, resentAt: now, inviteType: invite.invite_type });
 }
 
-export async function onRequest(c: any): Promise<Response> {
+export async function onRequest(c: AdminContext): Promise<Response> {
   if (c.req.raw.method !== "POST") {
     return json({ error: { code: "METHOD_NOT_ALLOWED", message: "Method not allowed" } }, 405);
   }

--- a/functions/api/v1/admin/events/[eventSlug]/invites/[inviteId]/router.ts
+++ b/functions/api/v1/admin/events/[eventSlug]/invites/[inviteId]/router.ts
@@ -1,8 +1,9 @@
 import { Hono } from "hono";
 import { fromHono } from "chanfana";
 import { onRequestPost as AdminEventsEventSlugInvitesInviteIdResendPost_l } from "./resend";
+import type { RequestDbContext } from "../../../../../../../_lib/db/context";
 
-const app = new Hono();
+const app = new Hono<RequestDbContext>();
 export const openapi = fromHono(app);
 
 app.post("/resend", AdminEventsEventSlugInvitesInviteIdResendPost_l);

--- a/functions/api/v1/admin/events/[eventSlug]/invites/attendees/bulk.ts
+++ b/functions/api/v1/admin/events/[eventSlug]/invites/attendees/bulk.ts
@@ -13,14 +13,15 @@ import {
   verifyAttendeeInvitePreviewToken,
 } from "../../../../../../../_lib/services/admin-invite-preview";
 import { adminBulkAttendeeInvitesSchema } from "../../../../../../../../assets/shared/schemas/api";
+import { requestDb, type AdminContext } from "../../../../../../../_lib/db/context";
 
 // Outcome buckets returned to the admin UI.
 type BulkItemResult = { email: string; inviteToken?: string };
 
-export async function onRequestPost(c: any): Promise<Response> {
-  const admin = await requireAdminFromRequest(c.env.DB, c.req.raw, c.env);
+export async function onRequestPost(c: AdminContext): Promise<Response> {
+  const admin = await requireAdminFromRequest(requestDb(c), c.req.raw, c.env);
   const body = await parseJsonBody(c.req, adminBulkAttendeeInvitesSchema);
-  const event = await getEventBySlug(c.env.DB, c.req.param("eventSlug"));
+  const event = await getEventBySlug(requestDb(c), c.req.param("eventSlug"));
   const appBaseUrl = resolveAppBaseUrl(c.env, c.req.raw);
   const secret = requireInternalSecret(c.env);
 
@@ -56,7 +57,7 @@ export async function onRequestPost(c: any): Promise<Response> {
 
   // Bulk-create invites: 3 D1 round-trips total (pre-check batch + token hashing + insert batch)
   // instead of N×4-6 sequential round-trips for N invites.
-  const outcomes = await bulkCreateAttendeesAdmin(c.env.DB, {
+  const outcomes = await bulkCreateAttendeesAdmin(requestDb(c), {
     event,
     invites: body.invites.map((i) => ({
       inviteeEmail: i.email,
@@ -83,7 +84,7 @@ export async function onRequestPost(c: any): Promise<Response> {
         declineUrl: inviteDeclineUrl(appBaseUrl, event, o.token!),
       },
     }));
-  await bulkQueueInviteEmails(c.env.DB, emailRows);
+  await bulkQueueInviteEmails(requestDb(c), emailRows);
 
   const created: BulkItemResult[] = outcomes
     .filter((o) => o.status === "created")
@@ -94,7 +95,7 @@ export async function onRequestPost(c: any): Promise<Response> {
   return json({ success: true, created, endorsed, skipped });
 }
 
-export async function onRequest(c: any): Promise<Response> {
+export async function onRequest(c: AdminContext): Promise<Response> {
   if (c.req.raw.method !== "POST") {
     return json({ error: { code: "METHOD_NOT_ALLOWED", message: "Method not allowed" } }, 405);
   }

--- a/functions/api/v1/admin/events/[eventSlug]/invites/attendees/preview.ts
+++ b/functions/api/v1/admin/events/[eventSlug]/invites/attendees/preview.ts
@@ -14,13 +14,14 @@ import {
   signAttendeeInvitePreviewToken,
 } from "../../../../../../../_lib/services/admin-invite-preview";
 import { adminBulkAttendeeInvitesPreviewSchema } from "../../../../../../../../assets/shared/schemas/api";
+import { requestDb, type AdminContext } from "../../../../../../../_lib/db/context";
 
 const PREVIEW_TTL_SECONDS = 10 * 60;
 
-export async function onRequestPost(c: any): Promise<Response> {
-  const admin = await requireAdminFromRequest(c.env.DB, c.req.raw, c.env);
+export async function onRequestPost(c: AdminContext): Promise<Response> {
+  const admin = await requireAdminFromRequest(requestDb(c), c.req.raw, c.env);
   const body = await parseJsonBody(c.req, adminBulkAttendeeInvitesPreviewSchema);
-  const event = await getEventBySlug(c.env.DB, c.req.param("eventSlug"));
+  const event = await getEventBySlug(requestDb(c), c.req.param("eventSlug"));
   const appBaseUrl = resolveAppBaseUrl(c.env, c.req.raw);
   const secret = requireInternalSecret(c.env);
 
@@ -35,8 +36,8 @@ export async function onRequestPost(c: any): Promise<Response> {
   });
   const declineUrl = inviteDeclineUrl(appBaseUrl, event, "preview-token");
 
-  const template = await resolveTemplate(c.env.DB, "attendee_invite");
-  const layoutHtml = await loadEmailLayout(c.env.DB);
+  const template = await resolveTemplate(requestDb(c), "attendee_invite");
+  const layoutHtml = await loadEmailLayout(requestDb(c));
   const digest = await computeAttendeeInviteDigest(body.invites);
   const preview = await signAttendeeInvitePreviewToken({
     secret,
@@ -76,7 +77,7 @@ export async function onRequestPost(c: any): Promise<Response> {
   });
 }
 
-export async function onRequest(c: any): Promise<Response> {
+export async function onRequest(c: AdminContext): Promise<Response> {
   if (c.req.raw.method !== "POST") {
     return json({ error: { code: "METHOD_NOT_ALLOWED", message: "Method not allowed" } }, 405);
   }

--- a/functions/api/v1/admin/events/[eventSlug]/invites/attendees/router.ts
+++ b/functions/api/v1/admin/events/[eventSlug]/invites/attendees/router.ts
@@ -2,8 +2,9 @@ import { Hono } from "hono";
 import { fromHono } from "chanfana";
 import { onRequestPost as AdminEventsEventSlugInvitesAttendeesBulkPost_l } from "./bulk";
 import { onRequestPost as AdminEventsEventSlugInvitesAttendeesPreviewPost_l } from "./preview";
+import type { RequestDbContext } from "../../../../../../../_lib/db/context";
 
-const app = new Hono();
+const app = new Hono<RequestDbContext>();
 export const openapi = fromHono(app);
 
 app.post("/bulk", AdminEventsEventSlugInvitesAttendeesBulkPost_l);

--- a/functions/api/v1/admin/events/[eventSlug]/invites/index.ts
+++ b/functions/api/v1/admin/events/[eventSlug]/invites/index.ts
@@ -2,6 +2,7 @@ import { json } from "../../../../../../_lib/http";
 import { requireAdminFromRequest } from "../../../../../../_lib/auth/admin";
 import { getEventBySlug } from "../../../../../../_lib/services/events";
 import { all, first } from "../../../../../../_lib/db/queries";
+import { requestDb, type AdminContext } from "../../../../../../_lib/db/context";
 
 /**
  * GET /api/v1/admin/events/:eventSlug/invites
@@ -11,10 +12,10 @@ import { all, first } from "../../../../../../_lib/db/queries";
  *   ?status=sent|accepted|declined|expired|revoked   (omit for all)
  *   ?type=attendee|speaker                            (omit for all)
  */
-export async function onRequestGet(c: any): Promise<Response> {
-  await requireAdminFromRequest(c.env.DB, c.req.raw, c.env);
+export async function onRequestGet(c: AdminContext): Promise<Response> {
+  await requireAdminFromRequest(requestDb(c), c.req.raw, c.env);
 
-  const event = await getEventBySlug(c.env.DB, c.req.param("eventSlug"));
+  const event = await getEventBySlug(requestDb(c), c.req.param("eventSlug"));
 
   const url = new URL(c.req.raw.url);
   const statusFilter = url.searchParams.get("status");
@@ -48,7 +49,7 @@ export async function onRequestGet(c: any): Promise<Response> {
   }
 
   const rows = await all(
-    c.env.DB,
+    requestDb(c),
     `SELECT
        i.id,
        i.invitee_email,
@@ -80,7 +81,7 @@ export async function onRequestGet(c: any): Promise<Response> {
   const hasMore = rows.length > limit;
   const invites = hasMore ? rows.slice(0, limit) : rows;
   const totalRow = await first<{ total: number }>(
-    c.env.DB,
+    requestDb(c),
     `SELECT COUNT(*) AS total
      FROM invites i
      WHERE ${conditions.join(" AND ")}`,
@@ -99,7 +100,7 @@ export async function onRequestGet(c: any): Promise<Response> {
   });
 }
 
-export async function onRequest(c: any): Promise<Response> {
+export async function onRequest(c: AdminContext): Promise<Response> {
   if (c.req.raw.method !== "GET") {
     return json({ error: { code: "METHOD_NOT_ALLOWED", message: "Method not allowed" } }, 405);
   }

--- a/functions/api/v1/admin/events/[eventSlug]/invites/router.ts
+++ b/functions/api/v1/admin/events/[eventSlug]/invites/router.ts
@@ -4,8 +4,9 @@ import { onRequestGet as AdminEventsEventSlugInvitesGet_l } from "./index";
 import inviteId_Router from "./[inviteId]/router";
 import attendees_Router from "./attendees/router";
 import speakers_Router from "./speakers/router";
+import type { RequestDbContext } from "../../../../../../_lib/db/context";
 
-const app = new Hono();
+const app = new Hono<RequestDbContext>();
 export const openapi = fromHono(app);
 
 app.get("/", AdminEventsEventSlugInvitesGet_l);

--- a/functions/api/v1/admin/events/[eventSlug]/invites/speakers/bulk.ts
+++ b/functions/api/v1/admin/events/[eventSlug]/invites/speakers/bulk.ts
@@ -7,16 +7,17 @@ import { resolveAppBaseUrl } from "../../../../../../../_lib/config";
 import { bulkQueueInviteEmails } from "../../../../../../../_lib/email/outbox";
 import { proposalPageUrl, inviteDeclineUrl } from "../../../../../../../_lib/services/frontend-links";
 import { adminBulkSpeakerInvitesSchema } from "../../../../../../../../assets/shared/schemas/api";
+import { requestDb, type AdminContext } from "../../../../../../../_lib/db/context";
 
-export async function onRequestPost(c: any): Promise<Response> {
-  await requireAdminFromRequest(c.env.DB, c.req.raw);
+export async function onRequestPost(c: AdminContext): Promise<Response> {
+  await requireAdminFromRequest(requestDb(c), c.req.raw, c.env);
   const body = await parseJsonBody(c.req, adminBulkSpeakerInvitesSchema);
-  const event = await getEventBySlug(c.env.DB, c.req.param("eventSlug"));
+  const event = await getEventBySlug(requestDb(c), c.req.param("eventSlug"));
   const appBaseUrl = resolveAppBaseUrl(c.env, c.req.raw);
 
-  const outcomes = await bulkCreateSpeakersAdmin(c.env.DB, {
+  const outcomes = await bulkCreateSpeakersAdmin(requestDb(c), {
     event,
-    invites: body.invites.map((item: any) => ({
+    invites: body.invites.map((item) => ({
       inviteeEmail: item.email,
       inviteeFirstName: item.firstName,
       inviteeLastName: item.lastName,
@@ -70,13 +71,13 @@ export async function onRequestPost(c: any): Promise<Response> {
   }
 
   if (emailRows.length > 0) {
-    await bulkQueueInviteEmails(c.env.DB, emailRows);
+    await bulkQueueInviteEmails(requestDb(c), emailRows);
   }
 
   return json({ success: true, created, endorsed, skipped });
 }
 
-export async function onRequest(c: any): Promise<Response> {
+export async function onRequest(c: AdminContext): Promise<Response> {
   if (c.req.raw.method !== "POST") {
     return json({ error: { code: "METHOD_NOT_ALLOWED", message: "Method not allowed" } }, 405);
   }

--- a/functions/api/v1/admin/events/[eventSlug]/invites/speakers/router.ts
+++ b/functions/api/v1/admin/events/[eventSlug]/invites/speakers/router.ts
@@ -1,8 +1,9 @@
 import { Hono } from "hono";
 import { fromHono } from "chanfana";
 import { onRequestPost as AdminEventsEventSlugInvitesSpeakersBulkPost_l } from "./bulk";
+import type { RequestDbContext } from "../../../../../../../_lib/db/context";
 
-const app = new Hono();
+const app = new Hono<RequestDbContext>();
 export const openapi = fromHono(app);
 
 app.post("/bulk", AdminEventsEventSlugInvitesSpeakersBulkPost_l);

--- a/functions/api/v1/admin/events/[eventSlug]/permissions.ts
+++ b/functions/api/v1/admin/events/[eventSlug]/permissions.ts
@@ -11,6 +11,7 @@ import { nowIso } from "../../../../../_lib/utils/time";
 import { uuid } from "../../../../../_lib/utils/ids";
 import { writeAuditLog } from "../../../../../_lib/services/audit";
 import { adminEventPermissionSchema } from "../../../../../../assets/shared/schemas/api";
+import { requestDb, type AdminContext } from "../../../../../_lib/db/context";
 
 interface PermissionRow {
   id: string;
@@ -26,12 +27,12 @@ interface ExistingPermRow {
   id: string;
 }
 
-export async function onRequestGet(c: any): Promise<Response> {
-  await requireAdminFromRequest(c.env.DB, c.req.raw, c.env);
-  const event = await getEventBySlug(c.env.DB, c.req.param("eventSlug"));
+export async function onRequestGet(c: AdminContext): Promise<Response> {
+  await requireAdminFromRequest(requestDb(c), c.req.raw, c.env);
+  const event = await getEventBySlug(requestDb(c), c.req.param("eventSlug"));
 
   const permissions = await all<PermissionRow>(
-    c.env.DB,
+    requestDb(c),
     `SELECT ep.id, ep.user_email, ep.user_id, ep.permission,
             ep.granted_by_id, ep.created_at,
             u.email AS granter_email
@@ -45,16 +46,16 @@ export async function onRequestGet(c: any): Promise<Response> {
   return json({ permissions });
 }
 
-export async function onRequestPost(c: any): Promise<Response> {
-  const admin = await requireAdminFromRequest(c.env.DB, c.req.raw, c.env);
+export async function onRequestPost(c: AdminContext): Promise<Response> {
+  const admin = await requireAdminFromRequest(requestDb(c), c.req.raw, c.env);
   const body = await parseJsonBody(c.req, adminEventPermissionSchema);
-  const event = await getEventBySlug(c.env.DB, c.req.param("eventSlug"));
+  const event = await getEventBySlug(requestDb(c), c.req.param("eventSlug"));
 
   const normalizedEmail = normalizeEmail(body.userEmail);
 
   // Check for duplicate
   const existing = await first<ExistingPermRow>(
-    c.env.DB,
+    requestDb(c),
     "SELECT id FROM event_permissions WHERE event_id = ? AND user_email = ? AND permission = ?",
     [event.id, normalizedEmail, body.permission],
   );
@@ -64,7 +65,7 @@ export async function onRequestPost(c: any): Promise<Response> {
   }
 
   // Resolve user_id if the person has an account
-  const userRow = await first<{ id: string }>(c.env.DB, "SELECT id FROM users WHERE normalized_email = ?", [
+  const userRow = await first<{ id: string }>(requestDb(c), "SELECT id FROM users WHERE normalized_email = ?", [
     normalizedEmail,
   ]);
 
@@ -72,13 +73,13 @@ export async function onRequestPost(c: any): Promise<Response> {
   const now = nowIso();
 
   await run(
-    c.env.DB,
+    requestDb(c),
     `INSERT INTO event_permissions (id, event_id, user_email, user_id, permission, granted_by_id, created_at)
      VALUES (?, ?, ?, ?, ?, ?, ?)`,
     [id, event.id, normalizedEmail, userRow?.id ?? null, body.permission, admin.id, now],
   );
 
-  await writeAuditLog(c.env.DB, "admin", admin.id, "event_permission_granted", "event", event.id, {
+  await writeAuditLog(requestDb(c), "admin", admin.id, "event_permission_granted", "event", event.id, {
     email: normalizedEmail,
     permission: body.permission,
   });
@@ -86,7 +87,7 @@ export async function onRequestPost(c: any): Promise<Response> {
   return json({ permission: { id, user_email: normalizedEmail, permission: body.permission, created_at: now } }, 201);
 }
 
-export async function onRequest(c: any): Promise<Response> {
+export async function onRequest(c: AdminContext): Promise<Response> {
   if (c.req.raw.method === "GET") return onRequestGet(c);
   if (c.req.raw.method === "POST") return onRequestPost(c);
   return json({ error: { code: "METHOD_NOT_ALLOWED", message: "Method not allowed" } }, 405);

--- a/functions/api/v1/admin/events/[eventSlug]/permissions/[permId].ts
+++ b/functions/api/v1/admin/events/[eventSlug]/permissions/[permId].ts
@@ -8,6 +8,7 @@ import { requireAdminFromRequest } from "../../../../../../_lib/auth/admin";
 import { getEventBySlug } from "../../../../../../_lib/services/events";
 import { first, run } from "../../../../../../_lib/db/queries";
 import { writeAuditLog } from "../../../../../../_lib/services/audit";
+import { requestDb, type AdminContext } from "../../../../../../_lib/db/context";
 
 interface PermRow {
   id: string;
@@ -15,12 +16,12 @@ interface PermRow {
   permission: string;
 }
 
-export async function onRequestDelete(c: any): Promise<Response> {
-  const admin = await requireAdminFromRequest(c.env.DB, c.req.raw, c.env);
-  const event = await getEventBySlug(c.env.DB, c.req.param("eventSlug"));
+export async function onRequestDelete(c: AdminContext): Promise<Response> {
+  const admin = await requireAdminFromRequest(requestDb(c), c.req.raw, c.env);
+  const event = await getEventBySlug(requestDb(c), c.req.param("eventSlug"));
 
   const perm = await first<PermRow>(
-    c.env.DB,
+    requestDb(c),
     "SELECT id, user_email, permission FROM event_permissions WHERE id = ? AND event_id = ?",
     [c.req.param("permId"), event.id],
   );
@@ -29,9 +30,9 @@ export async function onRequestDelete(c: any): Promise<Response> {
     return json({ error: { code: "NOT_FOUND", message: "Permission grant not found" } }, 404);
   }
 
-  await run(c.env.DB, "DELETE FROM event_permissions WHERE id = ?", [perm.id]);
+  await run(requestDb(c), "DELETE FROM event_permissions WHERE id = ?", [perm.id]);
 
-  await writeAuditLog(c.env.DB, "admin", admin.id, "event_permission_revoked", "event", event.id, {
+  await writeAuditLog(requestDb(c), "admin", admin.id, "event_permission_revoked", "event", event.id, {
     email: perm.user_email,
     permission: perm.permission,
   });
@@ -39,7 +40,7 @@ export async function onRequestDelete(c: any): Promise<Response> {
   return json({ success: true });
 }
 
-export async function onRequest(c: any): Promise<Response> {
+export async function onRequest(c: AdminContext): Promise<Response> {
   if (c.req.raw.method !== "DELETE") {
     return json({ error: { code: "METHOD_NOT_ALLOWED", message: "Method not allowed" } }, 405);
   }

--- a/functions/api/v1/admin/events/[eventSlug]/permissions/router.ts
+++ b/functions/api/v1/admin/events/[eventSlug]/permissions/router.ts
@@ -1,8 +1,9 @@
 import { Hono } from "hono";
 import { fromHono } from "chanfana";
 import { onRequestDelete as AdminEventsEventSlugPermissionsPermIdDelete_l } from "./[permId]";
+import type { RequestDbContext } from "../../../../../../_lib/db/context";
 
-const app = new Hono();
+const app = new Hono<RequestDbContext>();
 export const openapi = fromHono(app);
 
 app.delete("/:permId", AdminEventsEventSlugPermissionsPermIdDelete_l);

--- a/functions/api/v1/admin/events/[eventSlug]/promoters.ts
+++ b/functions/api/v1/admin/events/[eventSlug]/promoters.ts
@@ -2,6 +2,7 @@ import { json } from "../../../../../_lib/http";
 import { requireAdminFromRequest } from "../../../../../_lib/auth/admin";
 import { getEventBySlug } from "../../../../../_lib/services/events";
 import { all } from "../../../../../_lib/db/queries";
+import { requestDb, type AdminContext } from "../../../../../_lib/db/context";
 
 /**
  * GET /api/v1/admin/events/:eventSlug/promoters
@@ -12,10 +13,10 @@ import { all } from "../../../../../_lib/db/queries";
  *
  * Sorted by overall effectiveness: conversions desc, then acceptances desc, then invites sent desc.
  */
-export async function onRequestGet(c: any): Promise<Response> {
-  await requireAdminFromRequest(c.env.DB, c.req.raw, c.env);
+export async function onRequestGet(c: AdminContext): Promise<Response> {
+  await requireAdminFromRequest(requestDb(c), c.req.raw, c.env);
 
-  const event = await getEventBySlug(c.env.DB, c.req.param("eventSlug"));
+  const event = await getEventBySlug(requestDb(c), c.req.param("eventSlug"));
 
   // ── 1. Per-inviter invite stats ──────────────────────────────────────────
   const inviterStats = await all<{
@@ -32,7 +33,7 @@ export async function onRequestGet(c: any): Promise<Response> {
     invites_expired: number;
     last_invite_at: string | null;
   }>(
-    c.env.DB,
+    requestDb(c),
     `SELECT
        i.inviter_user_id,
        u.email             AS inviter_email,
@@ -75,7 +76,7 @@ export async function onRequestGet(c: any): Promise<Response> {
     total_clicks: number;
     total_conversions: number;
   }>(
-    c.env.DB,
+    requestDb(c),
     `SELECT
        COALESCE(rc.created_by_user_id, reg.user_id) AS effective_user_id,
        COALESCE(u1.email,      u2.email)      AS referrer_email,
@@ -118,7 +119,7 @@ export async function onRequestGet(c: any): Promise<Response> {
     conversions: number;
     created_at: string;
   }>(
-    c.env.DB,
+    requestDb(c),
     `SELECT
        rc.code,
        rc.owner_type,
@@ -143,7 +144,7 @@ export async function onRequestGet(c: any): Promise<Response> {
 
   // ── 4. Recent referral click timeline (last 30 days, by day) ─────────────
   const clickTimeline = await all<{ date: string; clicks: number }>(
-    c.env.DB,
+    requestDb(c),
     `SELECT
        date(created_at) AS date,
        COUNT(*)         AS clicks
@@ -256,7 +257,7 @@ export async function onRequestGet(c: any): Promise<Response> {
   });
 }
 
-export async function onRequest(c: any): Promise<Response> {
+export async function onRequest(c: AdminContext): Promise<Response> {
   if (c.req.raw.method !== "GET") {
     return json({ error: { code: "METHOD_NOT_ALLOWED", message: "Method not allowed" } }, 405);
   }

--- a/functions/api/v1/admin/events/[eventSlug]/proposals.ts
+++ b/functions/api/v1/admin/events/[eventSlug]/proposals.ts
@@ -4,11 +4,12 @@ import { getProposalAccessForEvent } from "../../../../../_lib/auth/proposal-acc
 import { getEventBySlug } from "../../../../../_lib/services/events";
 import { all, first } from "../../../../../_lib/db/queries";
 import type { ProposalListRecord } from "../../../../../_lib/services/proposals";
+import { requestDb, type AdminContext } from "../../../../../_lib/db/context";
 
-export async function onRequestGet(c: any): Promise<Response> {
-  const admin = await requireAdminFromRequest(c.env.DB, c.req.raw);
-  const event = await getEventBySlug(c.env.DB, c.req.param("eventSlug"));
-  const access = await getProposalAccessForEvent(c.env.DB, event.id, admin);
+export async function onRequestGet(c: AdminContext): Promise<Response> {
+  const admin = await requireAdminFromRequest(requestDb(c), c.req.raw, c.env);
+  const event = await getEventBySlug(requestDb(c), c.req.param("eventSlug"));
+  const access = await getProposalAccessForEvent(requestDb(c), event.id, admin);
 
   const url = new URL(c.req.raw.url);
   const status = url.searchParams.get("status")?.trim() ?? "";
@@ -33,7 +34,7 @@ export async function onRequestGet(c: any): Promise<Response> {
   }
 
   const rows = await all<ProposalListRecord>(
-    c.env.DB,
+    requestDb(c),
     `SELECT
        sp.*,
        u.email      AS proposer_email,
@@ -60,7 +61,7 @@ export async function onRequestGet(c: any): Promise<Response> {
   const hasMore = rows.length > limit;
   const proposals = hasMore ? rows.slice(0, limit) : rows;
   const totalRow = await first<{ total: number }>(
-    c.env.DB,
+    requestDb(c),
     `SELECT COUNT(*) AS total
      FROM session_proposals sp
      JOIN users u ON u.id = sp.proposer_user_id
@@ -82,7 +83,7 @@ export async function onRequestGet(c: any): Promise<Response> {
   });
 }
 
-export async function onRequest(c: any): Promise<Response> {
+export async function onRequest(c: AdminContext): Promise<Response> {
   if (c.req.raw.method !== "GET") {
     return json({ error: { code: "METHOD_NOT_ALLOWED", message: "Method not allowed" } }, 405);
   }

--- a/functions/api/v1/admin/events/[eventSlug]/registrations.ts
+++ b/functions/api/v1/admin/events/[eventSlug]/registrations.ts
@@ -2,6 +2,7 @@ import { json } from "../../../../../_lib/http";
 import { requireAdminFromRequest } from "../../../../../_lib/auth/admin";
 import { getEventBySlug } from "../../../../../_lib/services/events";
 import { all, first } from "../../../../../_lib/db/queries";
+import { requestDb, type AdminContext } from "../../../../../_lib/db/context";
 
 interface RegistrationRow {
   id: string;
@@ -24,9 +25,9 @@ interface WaitlistSummaryRow {
   count: number;
 }
 
-export async function onRequestGet(c: any): Promise<Response> {
-  await requireAdminFromRequest(c.env.DB, c.req.raw, c.env);
-  const event = await getEventBySlug(c.env.DB, c.req.param("eventSlug"));
+export async function onRequestGet(c: AdminContext): Promise<Response> {
+  await requireAdminFromRequest(requestDb(c), c.req.raw, c.env);
+  const event = await getEventBySlug(requestDb(c), c.req.param("eventSlug"));
 
   const url = new URL(c.req.raw.url);
   const limit = Math.min(200, Math.max(1, parseInt(url.searchParams.get("limit") ?? "50", 10) || 50));
@@ -74,7 +75,7 @@ export async function onRequestGet(c: any): Promise<Response> {
   const whereClause = conditions.join(" AND ");
 
   const registrationRows = await all<RegistrationRow>(
-    c.env.DB,
+    requestDb(c),
     `SELECT r.id, r.user_id, r.status, r.attendance_type, r.source_type, r.created_at, r.updated_at,
             u.email AS user_email,
             COALESCE(u.first_name || ' ' || u.last_name, u.first_name, u.email) AS display_name,
@@ -119,7 +120,7 @@ export async function onRequestGet(c: any): Promise<Response> {
   const waitlistSummaries =
     registrationIds.length > 0
       ? await all<WaitlistSummaryRow>(
-          c.env.DB,
+          requestDb(c),
           `SELECT
          w.registration_id,
          GROUP_CONCAT(CASE
@@ -150,20 +151,20 @@ export async function onRequestGet(c: any): Promise<Response> {
 
   const [totalRow, statRows, bouncedCountRow] = await Promise.all([
     first<{ total: number }>(
-      c.env.DB,
+      requestDb(c),
       `SELECT COUNT(*) AS total FROM registrations r LEFT JOIN users u ON u.id = r.user_id WHERE ${whereClause}`,
       bindings,
     ),
     // Aggregate stats always cover all registrations for the event (unfiltered)
     all<{ attendance_type: string; status: string; count: number }>(
-      c.env.DB,
+      requestDb(c),
       `SELECT attendance_type, status, COUNT(*) AS count
        FROM registrations WHERE event_id = ?
        GROUP BY attendance_type, status`,
       [event.id],
     ),
     first<{ bounced_count: number }>(
-      c.env.DB,
+      requestDb(c),
       `SELECT COUNT(DISTINCT r.id) AS bounced_count
        FROM registrations r
        WHERE r.event_id = ? AND EXISTS (
@@ -199,7 +200,7 @@ export async function onRequestGet(c: any): Promise<Response> {
   });
 }
 
-export async function onRequest(c: any): Promise<Response> {
+export async function onRequest(c: AdminContext): Promise<Response> {
   if (c.req.raw.method !== "GET") {
     return json({ error: { code: "METHOD_NOT_ALLOWED", message: "Method not allowed" } }, 405);
   }

--- a/functions/api/v1/admin/events/[eventSlug]/registrations/[registrationId]/admit.ts
+++ b/functions/api/v1/admin/events/[eventSlug]/registrations/[registrationId]/admit.ts
@@ -15,6 +15,7 @@ import { adminRegistrationAdmitSchema } from "../../../../../../../../assets/sha
 import { resolveAppBaseUrl } from "../../../../../../../_lib/config";
 import { processOutboxByIdBackground } from "../../../../../../../_lib/email/outbox";
 import { queueRegistrationStatusEmail } from "../../../../../../../_lib/services/registrations/status-notifications";
+import { requestDb, type AdminContext } from "../../../../../../../_lib/db/context";
 
 interface RegistrationRow {
   id: string;
@@ -24,14 +25,14 @@ interface RegistrationRow {
   attendance_type: "in_person" | "virtual" | "on_demand";
 }
 
-export async function onRequestPost(c: any): Promise<Response> {
-  const admin = await requireAdminFromRequest(c.env.DB, c.req.raw);
+export async function onRequestPost(c: AdminContext): Promise<Response> {
+  const admin = await requireAdminFromRequest(requestDb(c), c.req.raw, c.env);
   const body = await parseJsonBody(c.req, adminRegistrationAdmitSchema);
-  const event = await getEventBySlug(c.env.DB, c.req.param("eventSlug"));
+  const event = await getEventBySlug(requestDb(c), c.req.param("eventSlug"));
   const registrationId = c.req.param("registrationId");
 
   const registration = await first<RegistrationRow>(
-    c.env.DB,
+    requestDb(c),
     "SELECT id, event_id, user_id, status, attendance_type FROM registrations WHERE id = ? AND event_id = ?",
     [registrationId, event.id],
   );
@@ -48,19 +49,19 @@ export async function onRequestPost(c: any): Promise<Response> {
   }
 
   const reason = `${body.mode}:${body.reason}`;
-  await setRegistrationCapacityExempt(c.env.DB, {
+  await setRegistrationCapacityExempt(requestDb(c), {
     registrationId: registration.id,
     exempt: true,
     reason,
   });
 
   if (registration.status === "waitlisted") {
-    await run(c.env.DB, "UPDATE registrations SET status = 'registered', updated_at = ? WHERE id = ?", [
+    await run(requestDb(c), "UPDATE registrations SET status = 'registered', updated_at = ? WHERE id = ?", [
       nowIso(),
       registration.id,
     ]);
     await run(
-      c.env.DB,
+      requestDb(c),
       `UPDATE waitlist_entries
        SET status = 'removed', updated_at = ?
        WHERE event_id = ? AND registration_id = ? AND status IN ('waiting', 'offered')`,
@@ -68,7 +69,7 @@ export async function onRequestPost(c: any): Promise<Response> {
     );
   }
 
-  const eventDays = await listEventDays(c.env.DB, event.id);
+  const eventDays = await listEventDays(requestDb(c), event.id);
   let admittedDayDates: string[] = [];
 
   if (eventDays.length > 0) {
@@ -85,7 +86,7 @@ export async function onRequestPost(c: any): Promise<Response> {
       }
 
       await run(
-        c.env.DB,
+        requestDb(c),
         `INSERT INTO registration_day_attendance (
           id, registration_id, event_day_id, attendance_type, created_at, updated_at
         ) VALUES (?, ?, ?, 'in_person', ?, ?)
@@ -96,12 +97,12 @@ export async function onRequestPost(c: any): Promise<Response> {
     }
   }
 
-  const selections = (await getRegistrationDayAttendance(c.env.DB, registration.id)).map((entry) => ({
+  const selections = (await getRegistrationDayAttendance(requestDb(c), registration.id)).map((entry) => ({
     dayDate: entry.dayDate,
     attendanceType: entry.attendanceType,
   }));
 
-  await syncRegistrationDayWaitlist(c.env.DB, {
+  await syncRegistrationDayWaitlist(requestDb(c), {
     registrationId: registration.id,
     eventId: event.id,
     userId: registration.user_id,
@@ -109,7 +110,7 @@ export async function onRequestPost(c: any): Promise<Response> {
     capacityExemptReason: reason,
   });
 
-  await writeAuditLog(c.env.DB, "admin", admin.id, "registration_admitted", "registration", registration.id, {
+  await writeAuditLog(requestDb(c), "admin", admin.id, "registration_admitted", "registration", registration.id, {
     mode: body.mode,
     reason: body.reason,
     admittedDayDates,
@@ -117,16 +118,16 @@ export async function onRequestPost(c: any): Promise<Response> {
   });
 
   const appBaseUrl = resolveAppBaseUrl(c.env, c.req.raw);
-  const outbox = await queueRegistrationStatusEmail(c.env.DB, {
+  const outbox = await queueRegistrationStatusEmail(requestDb(c), {
     event,
     registrationId: registration.id,
     appBaseUrl,
     templateKey: "registration_updated",
     subject: `Registration updated for ${event.name}`,
   });
-  c.executionCtx.waitUntil(processOutboxByIdBackground(c.env.DB, c.env, outbox.outboxId));
+  c.executionCtx.waitUntil(processOutboxByIdBackground(requestDb(c), c.env, outbox.outboxId));
 
-  const updated = await first<Record<string, unknown>>(c.env.DB, "SELECT * FROM registrations WHERE id = ?", [
+  const updated = await first<Record<string, unknown>>(requestDb(c), "SELECT * FROM registrations WHERE id = ?", [
     registration.id,
   ]);
 
@@ -137,7 +138,7 @@ export async function onRequestPost(c: any): Promise<Response> {
   });
 }
 
-export async function onRequest(c: any): Promise<Response> {
+export async function onRequest(c: AdminContext): Promise<Response> {
   if (c.req.raw.method !== "POST") {
     return json({ error: { code: "METHOD_NOT_ALLOWED", message: "Method not allowed" } }, 405);
   }

--- a/functions/api/v1/admin/events/[eventSlug]/registrations/[registrationId]/audit-log.ts
+++ b/functions/api/v1/admin/events/[eventSlug]/registrations/[registrationId]/audit-log.ts
@@ -10,6 +10,7 @@ import { requireAdminFromRequest } from "../../../../../../../_lib/auth/admin";
 import { getEventBySlug } from "../../../../../../../_lib/services/events";
 import { first, all } from "../../../../../../../_lib/db/queries";
 import type { DatabaseLike } from "../../../../../../../_lib/types";
+import { requestDb, type AdminContext } from "../../../../../../../_lib/db/context";
 
 interface AuditLogRow {
   id: string;
@@ -45,13 +46,13 @@ async function fetchAuditLog(db: DatabaseLike, registrationId: string): Promise<
   );
 }
 
-export async function onRequestGet(c: any): Promise<Response> {
-  await requireAdminFromRequest(c.env.DB, c.req.raw, c.env);
-  const event = await getEventBySlug(c.env.DB, c.req.param("eventSlug"));
+export async function onRequestGet(c: AdminContext): Promise<Response> {
+  await requireAdminFromRequest(requestDb(c), c.req.raw, c.env);
+  const event = await getEventBySlug(requestDb(c), c.req.param("eventSlug"));
   const registrationId = c.req.param("registrationId");
 
   // Verify the registration belongs to this event
-  const reg = await first<{ id: string }>(c.env.DB, "SELECT id FROM registrations WHERE id = ? AND event_id = ?", [
+  const reg = await first<{ id: string }>(requestDb(c), "SELECT id FROM registrations WHERE id = ? AND event_id = ?", [
     registrationId,
     event.id,
   ]);
@@ -59,7 +60,7 @@ export async function onRequestGet(c: any): Promise<Response> {
     return json({ error: { code: "REGISTRATION_NOT_FOUND", message: "Registration not found" } }, 404);
   }
 
-  const entries = await fetchAuditLog(c.env.DB, registrationId);
+  const entries = await fetchAuditLog(requestDb(c), registrationId);
 
   // Parse details_json for the caller so it does not have to JSON.parse each row
   const parsed = entries.map((e) => ({

--- a/functions/api/v1/admin/events/[eventSlug]/registrations/[registrationId]/badge-role.ts
+++ b/functions/api/v1/admin/events/[eventSlug]/registrations/[registrationId]/badge-role.ts
@@ -30,6 +30,7 @@ import { uuid } from "../../../../../../../_lib/utils/ids";
 import type { DatabaseLike } from "../../../../../../../_lib/types";
 import { resolveAppBaseUrl } from "../../../../../../../_lib/config";
 import { z } from "zod";
+import { requestDb, type AdminContext } from "../../../../../../../_lib/db/context";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -100,10 +101,10 @@ async function fetchData(db: DatabaseLike, eventId: string, registrationId: stri
 
 // ── GET ───────────────────────────────────────────────────────────────────────
 
-export async function onRequestGet(c: any): Promise<Response> {
-  await requireAdminFromRequest(c.env.DB, c.req.raw, c.env);
-  const event = await getEventBySlug(c.env.DB, c.req.param("eventSlug"));
-  const data = await fetchData(c.env.DB, event.id, c.req.param("registrationId"));
+export async function onRequestGet(c: AdminContext): Promise<Response> {
+  await requireAdminFromRequest(requestDb(c), c.req.raw, c.env);
+  const event = await getEventBySlug(requestDb(c), c.req.param("eventSlug"));
+  const data = await fetchData(requestDb(c), event.id, c.req.param("registrationId"));
 
   if (!data) {
     return json({ error: { code: "REGISTRATION_NOT_FOUND", message: "Registration not found" } }, 404);
@@ -132,18 +133,18 @@ export async function onRequestGet(c: any): Promise<Response> {
 
 // ── PATCH ─────────────────────────────────────────────────────────────────────
 
-export async function onRequestPatch(c: any): Promise<Response> {
-  const admin = await requireAdminFromRequest(c.env.DB, c.req.raw, c.env);
-  const event = await getEventBySlug(c.env.DB, c.req.param("eventSlug"));
+export async function onRequestPatch(c: AdminContext): Promise<Response> {
+  const admin = await requireAdminFromRequest(requestDb(c), c.req.raw, c.env);
+  const event = await getEventBySlug(requestDb(c), c.req.param("eventSlug"));
   const body = await parseJsonBody(c.req, patchSchema);
-  const data = await fetchData(c.env.DB, event.id, c.req.param("registrationId"));
+  const data = await fetchData(requestDb(c), event.id, c.req.param("registrationId"));
 
   if (!data) {
     return json({ error: { code: "REGISTRATION_NOT_FOUND", message: "Registration not found" } }, 404);
   }
 
   const { registration, participantRows } = data;
-  const db = c.env.DB;
+  const db = requestDb(c);
   const now = nowIso();
 
   // Remove any existing admin-sourced non-attendee participant row
@@ -199,7 +200,7 @@ export async function onRequestPatch(c: any): Promise<Response> {
 
 // ── Catch-all ─────────────────────────────────────────────────────────────────
 
-export async function onRequest(c: any): Promise<Response> {
+export async function onRequest(c: AdminContext): Promise<Response> {
   if (c.req.raw.method === "GET") return onRequestGet(c);
   if (c.req.raw.method === "PATCH") return onRequestPatch(c);
   return json({ error: { code: "METHOD_NOT_ALLOWED", message: "Method not allowed" } }, 405);

--- a/functions/api/v1/admin/events/[eventSlug]/registrations/[registrationId]/day-attendance.ts
+++ b/functions/api/v1/admin/events/[eventSlug]/registrations/[registrationId]/day-attendance.ts
@@ -19,20 +19,21 @@ import { AppError } from "../../../../../../../_lib/errors";
 import { resolveAppBaseUrl } from "../../../../../../../_lib/config";
 import { queueRegistrationStatusEmail } from "../../../../../../../_lib/services/registrations/status-notifications";
 import { processOutboxByIdBackground } from "../../../../../../../_lib/email/outbox";
+import { requestDb, type AdminContext } from "../../../../../../../_lib/db/context";
 
 interface RegistrationRow {
   id: string;
   event_id: string;
 }
 
-export async function onRequestPatch(c: any): Promise<Response> {
-  const admin = await requireAdminFromRequest(c.env.DB, c.req.raw);
+export async function onRequestPatch(c: AdminContext): Promise<Response> {
+  const admin = await requireAdminFromRequest(requestDb(c), c.req.raw, c.env);
   const body = await parseJsonBody(c.req, adminManageDayAttendanceSchema);
-  const event = await getEventBySlug(c.env.DB, c.req.param("eventSlug"));
+  const event = await getEventBySlug(requestDb(c), c.req.param("eventSlug"));
   const registrationId = c.req.param("registrationId");
 
   const registration = await first<RegistrationRow>(
-    c.env.DB,
+    requestDb(c),
     "SELECT id, event_id FROM registrations WHERE id = ? AND event_id = ?",
     [registrationId, event.id],
   );
@@ -41,7 +42,7 @@ export async function onRequestPatch(c: any): Promise<Response> {
     throw new AppError(404, "NOT_FOUND", "Registration not found for this event");
   }
 
-  const eventDays = await listEventDays(c.env.DB, event.id);
+  const eventDays = await listEventDays(requestDb(c), event.id);
   const dayByDate = new Map(eventDays.map((day) => [day.day_date, day]));
 
   for (const dayDate of body.dayDates) {
@@ -51,13 +52,14 @@ export async function onRequestPatch(c: any): Promise<Response> {
     }
 
     if (body.action === "remove") {
-      await run(c.env.DB, `DELETE FROM registration_day_attendance WHERE registration_id = ? AND event_day_id = ?`, [
-        registration.id,
-        day.id,
-      ]);
+      await run(
+        requestDb(c),
+        `DELETE FROM registration_day_attendance WHERE registration_id = ? AND event_day_id = ?`,
+        [registration.id, day.id],
+      );
     } else {
       await run(
-        c.env.DB,
+        requestDb(c),
         `INSERT INTO registration_day_attendance (
            id, registration_id, event_day_id, attendance_type, created_at, updated_at
          ) VALUES (?, ?, ?, ?, ?, ?)
@@ -69,7 +71,7 @@ export async function onRequestPatch(c: any): Promise<Response> {
   }
 
   await writeAuditLog(
-    c.env.DB,
+    requestDb(c),
     "admin",
     admin.id,
     "registration_day_attendance_updated",
@@ -80,20 +82,20 @@ export async function onRequestPatch(c: any): Promise<Response> {
 
   if (body.action !== "remove") {
     const appBaseUrl = resolveAppBaseUrl(c.env, c.req.raw);
-    const outbox = await queueRegistrationStatusEmail(c.env.DB, {
+    const outbox = await queueRegistrationStatusEmail(requestDb(c), {
       event,
       registrationId: registration.id,
       appBaseUrl,
       templateKey: "registration_updated",
       subject: `Registration updated for ${event.name}`,
     });
-    c.executionCtx.waitUntil(processOutboxByIdBackground(c.env.DB, c.env, outbox.outboxId));
+    c.executionCtx.waitUntil(processOutboxByIdBackground(requestDb(c), c.env, outbox.outboxId));
   }
 
   return json({ success: true });
 }
 
-export async function onRequest(c: any): Promise<Response> {
+export async function onRequest(c: AdminContext): Promise<Response> {
   if (c.req.raw.method === "PATCH") return onRequestPatch(c);
   return json({ error: { code: "METHOD_NOT_ALLOWED", message: "Method not allowed" } }, 405);
 }

--- a/functions/api/v1/admin/events/[eventSlug]/registrations/[registrationId]/index.ts
+++ b/functions/api/v1/admin/events/[eventSlug]/registrations/[registrationId]/index.ts
@@ -29,6 +29,7 @@ import { z } from "zod";
 import { queueRegistrationStatusEmail } from "../../../../../../../_lib/services/registrations/status-notifications";
 import { registrationConfirmPageUrl } from "../../../../../../../_lib/services/frontend-links";
 import { buildAttendanceEmailData } from "../../../../../../../_lib/utils/attendance";
+import { requestDb, type AdminContext } from "../../../../../../../_lib/db/context";
 import {
   getAcceptedTermsTextForRegistration,
   getCustomAnswerRows,
@@ -74,17 +75,17 @@ async function fetchRegistrationWithDetails(
 
 // ── GET ───────────────────────────────────────────────────────────────────────
 
-export async function onRequestGet(c: any): Promise<Response> {
-  await requireAdminFromRequest(c.env.DB, c.req.raw, c.env);
-  const event = await getEventBySlug(c.env.DB, c.req.param("eventSlug"));
-  const registration = await fetchRegistrationWithDetails(c.env.DB, event.id, c.req.param("registrationId"));
+export async function onRequestGet(c: AdminContext): Promise<Response> {
+  await requireAdminFromRequest(requestDb(c), c.req.raw, c.env);
+  const event = await getEventBySlug(requestDb(c), c.req.param("eventSlug"));
+  const registration = await fetchRegistrationWithDetails(requestDb(c), event.id, c.req.param("registrationId"));
   if (!registration) {
     return json({ error: { code: "REGISTRATION_NOT_FOUND", message: "Registration not found" } }, 404);
   }
 
   const [dayAttendance, dayWaitlist] = await Promise.all([
-    getRegistrationDayAttendance(c.env.DB, registration.id),
-    listDayWaitlistForRegistration(c.env.DB, registration.id),
+    getRegistrationDayAttendance(requestDb(c), registration.id),
+    listDayWaitlistForRegistration(requestDb(c), registration.id),
   ]);
 
   return json({ registration, dayAttendance, dayWaitlist });
@@ -98,9 +99,9 @@ const adminRegistrationUpdateSchema = registrationManageSchema.omit({ action: tr
   status: z.enum(["pending_email_confirmation", "registered", "waitlisted", "cancelled"]).optional(),
 });
 
-export async function onRequestPatch(c: any): Promise<Response> {
-  const admin = await requireAdminFromRequest(c.env.DB, c.req.raw, c.env);
-  const event = await getEventBySlug(c.env.DB, c.req.param("eventSlug"));
+export async function onRequestPatch(c: AdminContext): Promise<Response> {
+  const admin = await requireAdminFromRequest(requestDb(c), c.req.raw, c.env);
+  const event = await getEventBySlug(requestDb(c), c.req.param("eventSlug"));
   const config = getConfig(c.env, c.req.raw);
   const registrationId = c.req.param("registrationId");
 
@@ -111,15 +112,16 @@ export async function onRequestPatch(c: any): Promise<Response> {
     if (!body.status) {
       return json({ error: { code: "MISSING_STATUS", message: "status is required for force_status action" } }, 400);
     }
-    const current = await fetchRegistrationWithDetails(c.env.DB, event.id, registrationId);
+    const current = await fetchRegistrationWithDetails(requestDb(c), event.id, registrationId);
     if (!current) {
       return json({ error: { code: "REGISTRATION_NOT_FOUND", message: "Registration not found" } }, 404);
     }
-    await c.env.DB.prepare("UPDATE registrations SET status = ?, updated_at = ? WHERE id = ?")
+    await requestDb(c)
+      .prepare("UPDATE registrations SET status = ?, updated_at = ? WHERE id = ?")
       .bind(body.status, nowIso(), registrationId)
       .run();
     await writeAuditLog(
-      c.env.DB,
+      requestDb(c),
       "admin",
       admin.id,
       "admin_registration_force_status",
@@ -134,7 +136,7 @@ export async function onRequestPatch(c: any): Promise<Response> {
 
     if (current.status !== body.status) {
       const appBaseUrl = resolveAppBaseUrl(c.env, c.req.raw);
-      const outbox = await queueRegistrationStatusEmail(c.env.DB, {
+      const outbox = await queueRegistrationStatusEmail(requestDb(c), {
         event,
         registrationId,
         appBaseUrl,
@@ -144,16 +146,16 @@ export async function onRequestPatch(c: any): Promise<Response> {
             ? `Registration cancelled and data removed — ${event.name}`
             : `Registration updated for ${event.name}`,
       });
-      c.executionCtx.waitUntil(processOutboxByIdBackground(c.env.DB, c.env, outbox.outboxId));
+      c.executionCtx.waitUntil(processOutboxByIdBackground(requestDb(c), c.env, outbox.outboxId));
     }
 
-    const updated = await fetchRegistrationWithDetails(c.env.DB, event.id, registrationId);
+    const updated = await fetchRegistrationWithDetails(requestDb(c), event.id, registrationId);
     return json({ success: true, registration: updated });
   }
 
   // ── update / cancel / report_unauthorized — full shared service logic ──────
   const customAnswers = body.customAnswers
-    ? await validateCustomAnswersByPurpose(c.env.DB, {
+    ? await validateCustomAnswersByPurpose(requestDb(c), {
         eventId: event.id,
         purpose: "event_registration",
         customAnswers: body.customAnswers,
@@ -161,7 +163,7 @@ export async function onRequestPatch(c: any): Promise<Response> {
     : {};
 
   const updated = await updateRegistrationById(
-    c.env.DB,
+    requestDb(c),
     {
       registrationId,
       action: body.action,
@@ -196,7 +198,8 @@ export async function onRequestPatch(c: any): Promise<Response> {
     }
     if (setParts.length > 0) {
       setValues.push(updated.user_id);
-      await c.env.DB.prepare(`UPDATE users SET ${setParts.join(", ")} WHERE id = ?`)
+      await requestDb(c)
+        .prepare(`UPDATE users SET ${setParts.join(", ")} WHERE id = ?`)
         .bind(...setValues)
         .run();
     }
@@ -208,12 +211,12 @@ export async function onRequestPatch(c: any): Promise<Response> {
   let emailChanged = false;
   if (body.action === "update" && body.email) {
     const currentUser = await first<{ normalized_email: string }>(
-      c.env.DB,
+      requestDb(c),
       "SELECT normalized_email FROM users WHERE id = ?",
       [updated.user_id],
     );
     if (currentUser && body.email.trim().toLowerCase() !== currentUser.normalized_email) {
-      const emailResult = await changeRegistrationEmail(c.env.DB, {
+      const emailResult = await changeRegistrationEmail(requestDb(c), {
         registrationId: updated.id,
         newEmail: body.email,
         confirmationTtlHours: config.manageTokenTtlHours,
@@ -242,13 +245,14 @@ export async function onRequestPatch(c: any): Promise<Response> {
         }
         if (setParts.length > 0) {
           setValues.push(emailResult.userId);
-          await c.env.DB.prepare(`UPDATE users SET ${setParts.join(", ")} WHERE id = ?`)
+          await requestDb(c)
+            .prepare(`UPDATE users SET ${setParts.join(", ")} WHERE id = ?`)
             .bind(...setValues)
             .run();
         }
       }
 
-      await writeAuditLog(c.env.DB, "admin", admin.id, "admin_email_changed", "registration", updated.id, {
+      await writeAuditLog(requestDb(c), "admin", admin.id, "admin_email_changed", "registration", updated.id, {
         eventId: event.id,
         previousEmail: emailResult.previousEmail,
         newEmail: emailResult.pendingEmail,
@@ -262,20 +266,20 @@ export async function onRequestPatch(c: any): Promise<Response> {
         last_name: string | null;
         organization_name: string | null;
         job_title: string | null;
-      }>(c.env.DB, "SELECT email, first_name, last_name, organization_name, job_title FROM users WHERE id = ?", [
+      }>(requestDb(c), "SELECT email, first_name, last_name, organization_name, job_title FROM users WHERE id = ?", [
         emailResult.userId,
       ]);
       if (userRecord) {
-        const dayAttendanceRaw = await getRegistrationDayAttendance(c.env.DB, updated.id);
-        const dayWaitlist = await listDayWaitlistForRegistration(c.env.DB, updated.id);
+        const dayAttendanceRaw = await getRegistrationDayAttendance(requestDb(c), updated.id);
+        const dayWaitlist = await listDayWaitlistForRegistration(requestDb(c), updated.id);
         const { attendanceLabel, dayAttendance } = buildAttendanceEmailData(
           updated.attendance_type,
           dayAttendanceRaw,
           dayWaitlist,
         );
-        const customAnswerRows = await getCustomAnswerRows(c.env.DB, event.id, updated.custom_answers_json);
-        const acceptedTermsText = await getAcceptedTermsTextForRegistration(c.env.DB, updated.id);
-        const outboxId = await queueEmail(c.env.DB, {
+        const customAnswerRows = await getCustomAnswerRows(requestDb(c), event.id, updated.custom_answers_json);
+        const acceptedTermsText = await getAcceptedTermsTextForRegistration(requestDb(c), updated.id);
+        const outboxId = await queueEmail(requestDb(c), {
           eventId: event.id,
           templateKey: "registration_confirm_email",
           recipientEmail: emailResult.pendingEmail,
@@ -301,7 +305,7 @@ export async function onRequestPatch(c: any): Promise<Response> {
             shareUrl: null,
           },
         });
-        c.executionCtx.waitUntil(processOutboxByIdBackground(c.env.DB, c.env, outboxId));
+        c.executionCtx.waitUntil(processOutboxByIdBackground(requestDb(c), c.env, outboxId));
       }
 
       emailChanged = true;
@@ -309,7 +313,7 @@ export async function onRequestPatch(c: any): Promise<Response> {
   }
 
   if (!emailChanged) {
-    const outbox = await queueRegistrationStatusEmail(c.env.DB, {
+    const outbox = await queueRegistrationStatusEmail(requestDb(c), {
       event,
       registrationId: updated.id,
       appBaseUrl,
@@ -319,21 +323,21 @@ export async function onRequestPatch(c: any): Promise<Response> {
           ? `Registration cancelled and data removed — ${event.name}`
           : `Registration updated for ${event.name}`,
     });
-    c.executionCtx.waitUntil(processOutboxByIdBackground(c.env.DB, c.env, outbox.outboxId));
+    c.executionCtx.waitUntil(processOutboxByIdBackground(requestDb(c), c.env, outbox.outboxId));
   }
 
-  await writeAuditLog(c.env.DB, "admin", admin.id, "admin_registration_updated", "registration", updated.id, {
+  await writeAuditLog(requestDb(c), "admin", admin.id, "admin_registration_updated", "registration", updated.id, {
     eventId: event.id,
     action: body.action,
   });
 
-  const result = await fetchRegistrationWithDetails(c.env.DB, event.id, updated.id);
+  const result = await fetchRegistrationWithDetails(requestDb(c), event.id, updated.id);
   return json({ success: true, registration: result, emailChanged });
 }
 
 // ── Router ────────────────────────────────────────────────────────────────────
 
-export async function onRequest(c: any): Promise<Response> {
+export async function onRequest(c: AdminContext): Promise<Response> {
   if (c.req.raw.method === "GET") return onRequestGet(c);
   if (c.req.raw.method === "PATCH") return onRequestPatch(c);
   return json({ error: { code: "METHOD_NOT_ALLOWED", message: "Method not allowed" } }, 405);

--- a/functions/api/v1/admin/events/[eventSlug]/registrations/[registrationId]/open-manage.ts
+++ b/functions/api/v1/admin/events/[eventSlug]/registrations/[registrationId]/open-manage.ts
@@ -18,21 +18,22 @@ import { registrationManagePageUrl } from "../../../../../../../_lib/services/fr
 import { writeAuditLog } from "../../../../../../../_lib/services/audit";
 import { signAdminManageJwt } from "../../../../../../../_lib/utils/jwt";
 import { json } from "../../../../../../../_lib/http";
+import { requestDb, type AdminContext } from "../../../../../../../_lib/db/context";
 
 const ADMIN_MANAGE_SESSION_MINUTES = 15;
 
-export async function onRequestPost(c: any): Promise<Response> {
+export async function onRequestPost(c: AdminContext): Promise<Response> {
   const secret = c.env.INTERNAL_SIGNING_SECRET;
   if (!secret) {
     return json({ error: { code: "SERVER_ERROR", message: "Signing secret not configured" } }, 500);
   }
 
-  const admin = await requireAdminFromRequest(c.env.DB, c.req.raw, c.env);
-  const event = await getEventBySlug(c.env.DB, c.req.param("eventSlug"));
+  const admin = await requireAdminFromRequest(requestDb(c), c.req.raw, c.env);
+  const event = await getEventBySlug(requestDb(c), c.req.param("eventSlug"));
   const registrationId = c.req.param("registrationId");
 
   const registration = await first<{ id: string }>(
-    c.env.DB,
+    requestDb(c),
     "SELECT id FROM registrations WHERE id = ? AND event_id = ?",
     [registrationId, event.id],
   );
@@ -53,7 +54,7 @@ export async function onRequestPost(c: any): Promise<Response> {
     ttlSeconds: ADMIN_MANAGE_SESSION_MINUTES * 60,
   });
 
-  await writeAuditLog(c.env.DB, "admin", admin.id, "admin_opened_manage_page", "registration", registrationId, {
+  await writeAuditLog(requestDb(c), "admin", admin.id, "admin_opened_manage_page", "registration", registrationId, {
     adminEmail: admin.email,
     eventSlug: event.slug,
   });

--- a/functions/api/v1/admin/events/[eventSlug]/registrations/[registrationId]/regenerate-badge.ts
+++ b/functions/api/v1/admin/events/[eventSlug]/registrations/[registrationId]/regenerate-badge.ts
@@ -18,18 +18,19 @@ import { getEventBySlug } from "../../../../../../../_lib/services/events";
 import { first } from "../../../../../../../_lib/db/queries";
 import { prerenderAndCache } from "../../../../../../../_lib/services/og-badge-prerender";
 import { writeAuditLog } from "../../../../../../../_lib/services/audit";
+import { requestDb, type AdminContext } from "../../../../../../../_lib/db/context";
 
 const R2_KEY_PREFIX = "og-badges/";
 
-export async function onRequestPost(c: any): Promise<Response> {
-  const admin = await requireAdminFromRequest(c.env.DB, c.req.raw, c.env);
-  const event = await getEventBySlug(c.env.DB, c.req.param("eventSlug"));
+export async function onRequestPost(c: AdminContext): Promise<Response> {
+  const admin = await requireAdminFromRequest(requestDb(c), c.req.raw, c.env);
+  const event = await getEventBySlug(requestDb(c), c.req.param("eventSlug"));
   const appBaseUrl = resolveAppBaseUrl(c.env, c.req.raw);
   const registrationId = c.req.param("registrationId");
 
   // Look up the referral code owned by this registration
   const row = await first<{ code: string }>(
-    c.env.DB,
+    requestDb(c),
     `SELECT code FROM referral_codes
      WHERE owner_type = 'registration'
        AND owner_id   = ?
@@ -52,7 +53,7 @@ export async function onRequestPost(c: any): Promise<Response> {
   // opens the badge URL immediately on success, so background-queue isn't safe here.
   await prerenderAndCache(row.code, c.env, appBaseUrl);
 
-  await writeAuditLog(c.env.DB, "admin", admin.id, "og_badge_regenerated", "registration", registrationId, {
+  await writeAuditLog(requestDb(c), "admin", admin.id, "og_badge_regenerated", "registration", registrationId, {
     referralCode: row.code,
   });
 

--- a/functions/api/v1/admin/events/[eventSlug]/registrations/[registrationId]/resend-confirmation.ts
+++ b/functions/api/v1/admin/events/[eventSlug]/registrations/[registrationId]/resend-confirmation.ts
@@ -30,16 +30,17 @@ import { generateSignedRsvpAddress } from "../../../../../../../_lib/email/rsvp"
 import { writeAuditLog } from "../../../../../../../_lib/services/audit";
 import type { RegistrationRecord } from "../../../../../../../_lib/services/registrations/types";
 import type { UserRecord } from "../../../../../../../_lib/services/users";
+import { requestDb, type AdminContext } from "../../../../../../../_lib/db/context";
 
-export async function onRequestPost(c: any): Promise<Response> {
-  const admin = await requireAdminFromRequest(c.env.DB, c.req.raw, c.env);
+export async function onRequestPost(c: AdminContext): Promise<Response> {
+  const admin = await requireAdminFromRequest(requestDb(c), c.req.raw, c.env);
   const config = getConfig(c.env, c.req.raw);
-  const event = await getEventBySlug(c.env.DB, c.req.param("eventSlug"));
+  const event = await getEventBySlug(requestDb(c), c.req.param("eventSlug"));
   const appBaseUrl = resolveAppBaseUrl(c.env, c.req.raw);
   const registrationId = c.req.param("registrationId");
 
   const registration = await first<RegistrationRecord>(
-    c.env.DB,
+    requestDb(c),
     "SELECT * FROM registrations WHERE id = ? AND event_id = ?",
     [registrationId, event.id],
   );
@@ -54,24 +55,24 @@ export async function onRequestPost(c: any): Promise<Response> {
     );
   }
 
-  const user = await first<UserRecord>(c.env.DB, "SELECT * FROM users WHERE id = ?", [registration.user_id]);
+  const user = await first<UserRecord>(requestDb(c), "SELECT * FROM users WHERE id = ?", [registration.user_id]);
   if (!user) {
     return json({ error: { code: "USER_NOT_FOUND", message: "Associated user not found" } }, 500);
   }
 
-  const dayAttendanceRaw = await getRegistrationDayAttendance(c.env.DB, registration.id);
-  const dayWaitlist = await listDayWaitlistForRegistration(c.env.DB, registration.id);
+  const dayAttendanceRaw = await getRegistrationDayAttendance(requestDb(c), registration.id);
+  const dayWaitlist = await listDayWaitlistForRegistration(requestDb(c), registration.id);
   const { attendanceLabel, dayAttendance } = buildAttendanceEmailData(
     registration.attendance_type,
     dayAttendanceRaw,
     dayWaitlist,
   );
-  const customAnswerRows = await getCustomAnswerRows(c.env.DB, event.id, registration.custom_answers_json);
-  const acceptedTermsText = await getAcceptedTermsTextForRegistration(c.env.DB, registration.id);
+  const customAnswerRows = await getCustomAnswerRows(requestDb(c), event.id, registration.custom_answers_json);
+  const acceptedTermsText = await getAcceptedTermsTextForRegistration(requestDb(c), registration.id);
 
   // Look up referral code for share URL
   const referralRow = await first<{ code: string }>(
-    c.env.DB,
+    requestDb(c),
     "SELECT code FROM referral_codes WHERE owner_type = 'registration' AND owner_id = ?",
     [registration.id],
   );
@@ -87,7 +88,7 @@ export async function onRequestPost(c: any): Promise<Response> {
     const newExpiresAt = addHours(now, config.manageTokenTtlHours);
 
     await run(
-      c.env.DB,
+      requestDb(c),
       `UPDATE registrations
        SET confirmation_token_hash = ?, confirmation_token_expires_at = ?, confirmation_reminder_sent_at = ?, updated_at = ?
        WHERE id = ?`,
@@ -96,7 +97,7 @@ export async function onRequestPost(c: any): Promise<Response> {
 
     const confirmationUrl = registrationConfirmPageUrl(appBaseUrl, event, newToken);
 
-    outboxId = await queueEmail(c.env.DB, {
+    outboxId = await queueEmail(requestDb(c), {
       eventId: event.id,
       baseUrl: appBaseUrl,
       templateKey: "registration_confirm_email",
@@ -128,7 +129,7 @@ export async function onRequestPost(c: any): Promise<Response> {
     const freshManageToken = randomToken(24);
     const freshManageHash = await sha256Hex(freshManageToken);
 
-    await run(c.env.DB, "UPDATE registrations SET manage_token_hash = ?, updated_at = ? WHERE id = ?", [
+    await run(requestDb(c), "UPDATE registrations SET manage_token_hash = ?, updated_at = ? WHERE id = ?", [
       freshManageHash,
       now,
       registration.id,
@@ -149,7 +150,7 @@ export async function onRequestPost(c: any): Promise<Response> {
       c.env.INTERNAL_SIGNING_SECRET,
     );
 
-    outboxId = await queueEmail(c.env.DB, {
+    outboxId = await queueEmail(requestDb(c), {
       eventId: event.id,
       baseUrl: appBaseUrl,
       templateKey: "registration_confirmed",
@@ -205,18 +206,26 @@ export async function onRequestPost(c: any): Promise<Response> {
     });
   }
 
-  c.executionCtx.waitUntil(processOutboxByIdBackground(c.env.DB, c.env, outboxId));
+  c.executionCtx.waitUntil(processOutboxByIdBackground(requestDb(c), c.env, outboxId));
 
-  await writeAuditLog(c.env.DB, "admin", admin.id, "admin_registration_email_resent", "registration", registration.id, {
-    eventId: event.id,
-    recipientEmail: user.email,
-    status: registration.status,
-  });
+  await writeAuditLog(
+    requestDb(c),
+    "admin",
+    admin.id,
+    "admin_registration_email_resent",
+    "registration",
+    registration.id,
+    {
+      eventId: event.id,
+      recipientEmail: user.email,
+      status: registration.status,
+    },
+  );
 
   return json({ success: true, message: "Email queued" });
 }
 
-export async function onRequest(c: any): Promise<Response> {
+export async function onRequest(c: AdminContext): Promise<Response> {
   if (c.req.raw.method !== "POST") {
     return json({ error: { code: "METHOD_NOT_ALLOWED", message: "Method not allowed" } }, 405);
   }

--- a/functions/api/v1/admin/events/[eventSlug]/registrations/[registrationId]/router.ts
+++ b/functions/api/v1/admin/events/[eventSlug]/registrations/[registrationId]/router.ts
@@ -10,8 +10,9 @@ import { onRequestPatch as AdminEventsEventSlugRegistrationsRegistrationIdPatch_
 import { onRequestPost as AdminEventsEventSlugRegistrationsRegistrationIdOpenManagePost_l } from "./open-manage";
 import { onRequestPost as AdminEventsEventSlugRegistrationsRegistrationIdRegenerateBadgePost_l } from "./regenerate-badge";
 import { onRequestPost as AdminEventsEventSlugRegistrationsRegistrationIdResendConfirmationPost_l } from "./resend-confirmation";
+import type { RequestDbContext } from "../../../../../../../_lib/db/context";
 
-const app = new Hono();
+const app = new Hono<RequestDbContext>();
 export const openapi = fromHono(app);
 
 app.post("/admit", AdminEventsEventSlugRegistrationsRegistrationIdAdmitPost_l);

--- a/functions/api/v1/admin/events/[eventSlug]/registrations/router.ts
+++ b/functions/api/v1/admin/events/[eventSlug]/registrations/router.ts
@@ -1,8 +1,9 @@
 import { Hono } from "hono";
 import { fromHono } from "chanfana";
 import registrationId_Router from "./[registrationId]/router";
+import type { RequestDbContext } from "../../../../../../_lib/db/context";
 
-const app = new Hono();
+const app = new Hono<RequestDbContext>();
 export const openapi = fromHono(app);
 
 app.route("/:registrationId", registrationId_Router);

--- a/functions/api/v1/admin/events/[eventSlug]/router.ts
+++ b/functions/api/v1/admin/events/[eventSlug]/router.ts
@@ -19,8 +19,9 @@ import invites_Router from "./invites/router";
 import permissions_Router from "./permissions/router";
 import registrations_Router from "./registrations/router";
 import waitlist_Router from "./waitlist/router";
+import type { RequestDbContext } from "../../../../../_lib/db/context";
 
-const app = new Hono();
+const app = new Hono<RequestDbContext>();
 export const openapi = fromHono(app);
 
 app.get("/days", AdminEventsEventSlugDaysGet_l);

--- a/functions/api/v1/admin/events/[eventSlug]/settings.ts
+++ b/functions/api/v1/admin/events/[eventSlug]/settings.ts
@@ -16,12 +16,13 @@ import { parseJsonSafe, stringifyJson } from "../../../../../_lib/utils/json";
 import { writeAuditLog } from "../../../../../_lib/services/audit";
 import { adminEventSettingsSchema } from "../../../../../../assets/shared/schemas/api";
 import { resolveAppBaseUrl } from "../../../../../_lib/config";
+import { requestDb, type AdminContext } from "../../../../../_lib/db/context";
 
-export async function onRequestPatch(c: any): Promise<Response> {
-  const admin = await requireAdminFromRequest(c.env.DB, c.req.raw, c.env);
+export async function onRequestPatch(c: AdminContext): Promise<Response> {
+  const admin = await requireAdminFromRequest(requestDb(c), c.req.raw, c.env);
   const body = await parseJsonBody(c.req, adminEventSettingsSchema);
 
-  const event = await getEventBySlug(c.env.DB, c.req.param("eventSlug"));
+  const event = await getEventBySlug(requestDb(c), c.req.param("eventSlug"));
 
   // ── Merge settings_json — preserve existing keys and fold in updates ──────
   const existingSettings = parseJsonSafe<Record<string, unknown>>(event.settings_json, {});
@@ -78,7 +79,7 @@ export async function onRequestPatch(c: any): Promise<Response> {
   // ── Core event fields — use COALESCE so omitted fields are preserved ──────
   // starts_at / ends_at accept an explicit null to clear.
   await run(
-    c.env.DB,
+    requestDb(c),
     `UPDATE events
      SET name                  = COALESCE(?, name),
          timezone              = COALESCE(?, timezone),
@@ -107,7 +108,7 @@ export async function onRequestPatch(c: any): Promise<Response> {
 
   if (body.userRetentionDays) {
     await run(
-      c.env.DB,
+      requestDb(c),
       `INSERT INTO retention_policies (event_id, user_retention_days, updated_at)
        VALUES (?, ?, ?)
        ON CONFLICT(event_id)
@@ -116,11 +117,11 @@ export async function onRequestPatch(c: any): Promise<Response> {
     );
   }
 
-  await writeAuditLog(c.env.DB, "admin", admin.id, "event_settings_updated", "event", event.id, body);
+  await writeAuditLog(requestDb(c), "admin", admin.id, "event_settings_updated", "event", event.id, body);
 
-  const updated = await getEventBySlug(c.env.DB, c.req.param("eventSlug"));
+  const updated = await getEventBySlug(requestDb(c), c.req.param("eventSlug"));
   const retention = await first<{ user_retention_days: number }>(
-    c.env.DB,
+    requestDb(c),
     "SELECT user_retention_days FROM retention_policies WHERE event_id = ?",
     [event.id],
   );
@@ -135,7 +136,7 @@ export async function onRequestPatch(c: any): Promise<Response> {
   });
 }
 
-export async function onRequest(c: any): Promise<Response> {
+export async function onRequest(c: AdminContext): Promise<Response> {
   if (c.req.raw.method !== "PATCH") {
     return json({ error: { code: "METHOD_NOT_ALLOWED", message: "Method not allowed" } }, 405);
   }

--- a/functions/api/v1/admin/events/[eventSlug]/stats.ts
+++ b/functions/api/v1/admin/events/[eventSlug]/stats.ts
@@ -2,6 +2,7 @@ import { json } from "../../../../../_lib/http";
 import { requireAdminFromRequest } from "../../../../../_lib/auth/admin";
 import { getEventBySlug } from "../../../../../_lib/services/events";
 import { all } from "../../../../../_lib/db/queries";
+import { requestDb, type AdminContext } from "../../../../../_lib/db/context";
 
 /**
  * GET /api/v1/admin/events/:eventSlug/stats
@@ -13,11 +14,11 @@ import { all } from "../../../../../_lib/db/queries";
  * - Invite funnel with decline reason breakdown
  * - Proposal status breakdown
  */
-export async function onRequestGet(c: any): Promise<Response> {
-  await requireAdminFromRequest(c.env.DB, c.req.raw, c.env);
+export async function onRequestGet(c: AdminContext): Promise<Response> {
+  await requireAdminFromRequest(requestDb(c), c.req.raw, c.env);
 
-  const event = await getEventBySlug(c.env.DB, c.req.param("eventSlug"));
-  const db = c.env.DB;
+  const event = await getEventBySlug(requestDb(c), c.req.param("eventSlug"));
+  const db = requestDb(c);
 
   const [
     regStatusRows,
@@ -209,7 +210,7 @@ export async function onRequestGet(c: any): Promise<Response> {
   });
 }
 
-export async function onRequest(c: any): Promise<Response> {
+export async function onRequest(c: AdminContext): Promise<Response> {
   if (c.req.raw.method !== "GET") {
     return json({ error: { code: "METHOD_NOT_ALLOWED", message: "Method not allowed" } }, 405);
   }

--- a/functions/api/v1/admin/events/[eventSlug]/terms.ts
+++ b/functions/api/v1/admin/events/[eventSlug]/terms.ts
@@ -16,6 +16,7 @@ import { uuid } from "../../../../../_lib/utils/ids";
 import { writeAuditLog } from "../../../../../_lib/services/audit";
 import type { DatabaseLike } from "../../../../../_lib/types";
 import { adminEventTermsReplaceSchema } from "../../../../../../assets/shared/schemas/api";
+import { requestDb, type AdminContext } from "../../../../../_lib/db/context";
 
 interface TermRow {
   id: string;
@@ -44,23 +45,23 @@ async function listTerms(db: DatabaseLike, eventId: string): Promise<{ attendee:
   };
 }
 
-export async function onRequestGet(c: any): Promise<Response> {
-  await requireAdminFromRequest(c.env.DB, c.req.raw, c.env);
-  const event = await getEventBySlug(c.env.DB, c.req.param("eventSlug"));
-  const terms = await listTerms(c.env.DB, event.id);
+export async function onRequestGet(c: AdminContext): Promise<Response> {
+  await requireAdminFromRequest(requestDb(c), c.req.raw, c.env);
+  const event = await getEventBySlug(requestDb(c), c.req.param("eventSlug"));
+  const terms = await listTerms(requestDb(c), event.id);
   return json({ terms });
 }
 
-export async function onRequestPut(c: any): Promise<Response> {
-  const admin = await requireAdminFromRequest(c.env.DB, c.req.raw, c.env);
+export async function onRequestPut(c: AdminContext): Promise<Response> {
+  const admin = await requireAdminFromRequest(requestDb(c), c.req.raw, c.env);
   const body = await parseJsonBody(c.req, adminEventTermsReplaceSchema);
-  const event = await getEventBySlug(c.env.DB, c.req.param("eventSlug"));
+  const event = await getEventBySlug(requestDb(c), c.req.param("eventSlug"));
 
   // Replace attendee terms preserving help_text (not in the base replaceEventTerms service)
   for (const audienceType of ["attendee", "speaker"] as const) {
     const termList = audienceType === "attendee" ? body.attendee : body.speaker;
 
-    await run(c.env.DB, "UPDATE event_terms SET active = 0 WHERE event_id = ? AND audience_type = ?", [
+    await run(requestDb(c), "UPDATE event_terms SET active = 0 WHERE event_id = ? AND audience_type = ?", [
       event.id,
       audienceType,
     ]);
@@ -68,7 +69,7 @@ export async function onRequestPut(c: any): Promise<Response> {
     const now = nowIso();
     for (const term of termList) {
       await run(
-        c.env.DB,
+        requestDb(c),
         `INSERT INTO event_terms (
           id, event_id, audience_type, term_key, version, required, content_ref, display_text, help_text, active, created_at
         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?)
@@ -95,16 +96,16 @@ export async function onRequestPut(c: any): Promise<Response> {
     }
   }
 
-  await writeAuditLog(c.env.DB, "admin", admin.id, "event_terms_replaced", "event", event.id, {
+  await writeAuditLog(requestDb(c), "admin", admin.id, "event_terms_replaced", "event", event.id, {
     attendeeCount: body.attendee.length,
     speakerCount: body.speaker.length,
   });
 
-  const updatedTerms = await listTerms(c.env.DB, event.id);
+  const updatedTerms = await listTerms(requestDb(c), event.id);
   return json({ success: true, terms: updatedTerms });
 }
 
-export async function onRequest(c: any): Promise<Response> {
+export async function onRequest(c: AdminContext): Promise<Response> {
   if (c.req.raw.method === "GET") return onRequestGet(c);
   if (c.req.raw.method === "PUT") return onRequestPut(c);
   return json({ error: { code: "METHOD_NOT_ALLOWED", message: "Method not allowed" } }, 405);

--- a/functions/api/v1/admin/events/[eventSlug]/waitlist/promote.ts
+++ b/functions/api/v1/admin/events/[eventSlug]/waitlist/promote.ts
@@ -8,10 +8,11 @@ import { queueRegistrationStatusEmail } from "../../../../../../_lib/services/re
 import { processOutboxByIdBackground } from "../../../../../../_lib/email/outbox";
 import { writeAuditLog } from "../../../../../../_lib/services/audit";
 import { resolveAppBaseUrl, getConfig } from "../../../../../../_lib/config";
+import { requestDb, type AdminContext } from "../../../../../../_lib/db/context";
 
-export async function onRequestPost(c: any): Promise<Response> {
-  const admin = await requireAdminFromRequest(c.env.DB, c.req.raw);
-  const event = await getEventBySlug(c.env.DB, c.req.param("eventSlug"));
+export async function onRequestPost(c: AdminContext): Promise<Response> {
+  const admin = await requireAdminFromRequest(requestDb(c), c.req.raw, c.env);
+  const event = await getEventBySlug(requestDb(c), c.req.param("eventSlug"));
   const config = getConfig(c.env, c.req.raw);
   const appBaseUrl = resolveAppBaseUrl(c.env, c.req.raw);
 
@@ -22,7 +23,7 @@ export async function onRequestPost(c: any): Promise<Response> {
   if (typeof event.capacity_in_person === "number" && event.capacity_in_person > 0) {
     while (true) {
       const promoted = await promoteWaitlistIfCapacity(
-        c.env.DB,
+        requestDb(c),
         event.id,
         event.capacity_in_person,
         config.waitlistClaimWindowHours,
@@ -35,10 +36,10 @@ export async function onRequestPost(c: any): Promise<Response> {
     }
   }
 
-  const eventDays = await listEventDays(c.env.DB, event.id);
+  const eventDays = await listEventDays(requestDb(c), event.id);
   for (const day of eventDays) {
     while (true) {
-      const promoted = await promoteDayWaitlistIfCapacity(c.env.DB, {
+      const promoted = await promoteDayWaitlistIfCapacity(requestDb(c), {
         eventId: event.id,
         eventDayId: day.id,
         claimWindowHours: config.waitlistClaimWindowHours,
@@ -53,7 +54,7 @@ export async function onRequestPost(c: any): Promise<Response> {
 
   const outboxIds: string[] = [];
   for (const registrationId of affectedRegistrations) {
-    const outbox = await queueRegistrationStatusEmail(c.env.DB, {
+    const outbox = await queueRegistrationStatusEmail(requestDb(c), {
       event,
       registrationId,
       appBaseUrl,
@@ -64,14 +65,14 @@ export async function onRequestPost(c: any): Promise<Response> {
     outboxIds.push(outbox.outboxId);
   }
 
-  await writeAuditLog(c.env.DB, "admin", admin.id, "admin_waitlist_promoted", "event", event.id, {
+  await writeAuditLog(requestDb(c), "admin", admin.id, "admin_waitlist_promoted", "event", event.id, {
     wholeRegistrationOffers,
     dayRegistrationOffers,
     affectedRegistrations: Array.from(affectedRegistrations),
   });
 
   c.executionCtx.waitUntil(
-    Promise.all(outboxIds.map((outboxId) => processOutboxByIdBackground(c.env.DB, c.env, outboxId))),
+    Promise.all(outboxIds.map((outboxId) => processOutboxByIdBackground(requestDb(c), c.env, outboxId))),
   );
 
   return json({
@@ -82,7 +83,7 @@ export async function onRequestPost(c: any): Promise<Response> {
   });
 }
 
-export async function onRequest(c: any): Promise<Response> {
+export async function onRequest(c: AdminContext): Promise<Response> {
   if (c.req.raw.method !== "POST") {
     return json({ error: { code: "METHOD_NOT_ALLOWED", message: "Method not allowed" } }, 405);
   }

--- a/functions/api/v1/admin/events/[eventSlug]/waitlist/router.ts
+++ b/functions/api/v1/admin/events/[eventSlug]/waitlist/router.ts
@@ -1,8 +1,9 @@
 import { Hono } from "hono";
 import { fromHono } from "chanfana";
 import { onRequestPost as AdminEventsEventSlugWaitlistPromotePost_l } from "./promote";
+import type { RequestDbContext } from "../../../../../../_lib/db/context";
 
-const app = new Hono();
+const app = new Hono<RequestDbContext>();
 export const openapi = fromHono(app);
 
 app.post("/promote", AdminEventsEventSlugWaitlistPromotePost_l);

--- a/functions/api/v1/admin/events/router.ts
+++ b/functions/api/v1/admin/events/router.ts
@@ -2,8 +2,9 @@ import { Hono } from "hono";
 import { fromHono } from "chanfana";
 import { onRequestPost as AdminEventsSyncFromHugoPost_l } from "./sync-from-hugo";
 import eventSlug_Router from "./[eventSlug]/router";
+import type { RequestDbContext } from "../../../../_lib/db/context";
 
-const app = new Hono();
+const app = new Hono<RequestDbContext>();
 export const openapi = fromHono(app);
 
 app.post("/sync-from-hugo", AdminEventsSyncFromHugoPost_l);

--- a/functions/api/v1/admin/events/sync-from-hugo.ts
+++ b/functions/api/v1/admin/events/sync-from-hugo.ts
@@ -4,9 +4,10 @@ import { requireAdminFromRequest } from "../../../../_lib/auth/admin";
 import { replaceEventTerms, upsertEventFromHugo } from "../../../../_lib/services/events";
 import { writeAuditLog } from "../../../../_lib/services/audit";
 import { adminEventSyncSchema } from "../../../../../assets/shared/schemas/api";
+import { requestDb, type AdminContext } from "../../../../_lib/db/context";
 
-export async function onRequestPost(c: any): Promise<Response> {
-  const admin = await requireAdminFromRequest(c.env.DB, c.req.raw);
+export async function onRequestPost(c: AdminContext): Promise<Response> {
+  const admin = await requireAdminFromRequest(requestDb(c), c.req.raw, c.env);
   const body = await parseJsonBody(c.req, adminEventSyncSchema);
 
   const settings = {
@@ -14,22 +15,24 @@ export async function onRequestPost(c: any): Promise<Response> {
     ...(body.event.frontend ? { frontend: body.event.frontend } : {}),
   };
 
-  const event = await upsertEventFromHugo(c.env.DB, {
+  const event = await upsertEventFromHugo(requestDb(c), {
     ...body.event,
     settings,
   });
 
   if (body.terms) {
-    await replaceEventTerms(c.env.DB, event.id, "attendee", body.terms.attendee);
-    await replaceEventTerms(c.env.DB, event.id, "speaker", body.terms.speaker);
+    await replaceEventTerms(requestDb(c), event.id, "attendee", body.terms.attendee);
+    await replaceEventTerms(requestDb(c), event.id, "speaker", body.terms.speaker);
   }
 
-  await writeAuditLog(c.env.DB, "admin", admin.id, "event_synced_from_hugo", "event", event.id, { slug: event.slug });
+  await writeAuditLog(requestDb(c), "admin", admin.id, "event_synced_from_hugo", "event", event.id, {
+    slug: event.slug,
+  });
 
   return json({ success: true, event });
 }
 
-export async function onRequest(c: any): Promise<Response> {
+export async function onRequest(c: AdminContext): Promise<Response> {
   if (c.req.raw.method !== "POST") {
     return json({ error: { code: "METHOD_NOT_ALLOWED", message: "Method not allowed" } }, 405);
   }

--- a/functions/api/v1/admin/forms/[formKey]/index.ts
+++ b/functions/api/v1/admin/forms/[formKey]/index.ts
@@ -21,6 +21,7 @@ import { AppError } from "../../../../../_lib/errors";
 import { writeAuditLog } from "../../../../../_lib/services/audit";
 import type { DatabaseLike } from "../../../../../_lib/types";
 import { adminFormUpdateSchema } from "../../../../../../assets/shared/schemas/api";
+import { requestDb, type AdminContext } from "../../../../../_lib/db/context";
 
 interface FormRow {
   id: string;
@@ -71,21 +72,21 @@ function mapFields(fields: FieldRow[]) {
   }));
 }
 
-export async function onRequestGet(c: any): Promise<Response> {
-  await requireAdminFromRequest(c.env.DB, c.req.raw, c.env);
-  const { form, fields } = await getFormWithFields(c.env.DB, c.req.param("formKey"));
+export async function onRequestGet(c: AdminContext): Promise<Response> {
+  await requireAdminFromRequest(requestDb(c), c.req.raw, c.env);
+  const { form, fields } = await getFormWithFields(requestDb(c), c.req.param("formKey"));
   return json({ form, fields: mapFields(fields) });
 }
 
-export async function onRequestPatch(c: any): Promise<Response> {
-  const admin = await requireAdminFromRequest(c.env.DB, c.req.raw, c.env);
+export async function onRequestPatch(c: AdminContext): Promise<Response> {
+  const admin = await requireAdminFromRequest(requestDb(c), c.req.raw, c.env);
   const body = await parseJsonBody(c.req, adminFormUpdateSchema);
-  const { form } = await getFormWithFields(c.env.DB, c.req.param("formKey"));
+  const { form } = await getFormWithFields(requestDb(c), c.req.param("formKey"));
   const now = nowIso();
 
   if (body.title !== undefined || body.description !== undefined || body.status !== undefined) {
     await run(
-      c.env.DB,
+      requestDb(c),
       `UPDATE forms
        SET title = COALESCE(?, title),
            description = IIF(? = 1, description, ?),
@@ -104,10 +105,10 @@ export async function onRequestPatch(c: any): Promise<Response> {
   }
 
   if (body.fields !== undefined) {
-    await run(c.env.DB, "DELETE FROM form_fields WHERE form_id = ?", [form.id]);
+    await run(requestDb(c), "DELETE FROM form_fields WHERE form_id = ?", [form.id]);
     for (const field of body.fields) {
       await run(
-        c.env.DB,
+        requestDb(c),
         `INSERT INTO form_fields (id, form_id, key, label, field_type, required, options_json, validation_json, sort_order, created_at)
          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
         [
@@ -124,44 +125,44 @@ export async function onRequestPatch(c: any): Promise<Response> {
         ],
       );
     }
-    await run(c.env.DB, "UPDATE forms SET updated_at = ? WHERE id = ?", [now, form.id]);
+    await run(requestDb(c), "UPDATE forms SET updated_at = ? WHERE id = ?", [now, form.id]);
   }
 
-  await writeAuditLog(c.env.DB, "admin", admin.id, "form_updated", "form", form.id, {
+  await writeAuditLog(requestDb(c), "admin", admin.id, "form_updated", "form", form.id, {
     key: form.key,
     fieldsReplaced: body.fields !== undefined,
   });
 
-  const updated = await getFormWithFields(c.env.DB, c.req.param("formKey"));
+  const updated = await getFormWithFields(requestDb(c), c.req.param("formKey"));
   return json({ success: true, form: updated.form, fields: mapFields(updated.fields) });
 }
 
-export async function onRequestDelete(c: any): Promise<Response> {
-  const admin = await requireAdminFromRequest(c.env.DB, c.req.raw, c.env);
-  const { form } = await getFormWithFields(c.env.DB, c.req.param("formKey"));
+export async function onRequestDelete(c: AdminContext): Promise<Response> {
+  const admin = await requireAdminFromRequest(requestDb(c), c.req.raw, c.env);
+  const { form } = await getFormWithFields(requestDb(c), c.req.param("formKey"));
 
   const subCount = await first<{ n: number }>(
-    c.env.DB,
+    requestDb(c),
     "SELECT COUNT(*) AS n FROM form_submissions WHERE form_id = ?",
     [form.id],
   );
 
   if ((subCount?.n ?? 0) > 0) {
-    await run(c.env.DB, "UPDATE forms SET status = 'archived', updated_at = ? WHERE id = ?", [nowIso(), form.id]);
-    await writeAuditLog(c.env.DB, "admin", admin.id, "form_archived", "form", form.id, { key: form.key });
+    await run(requestDb(c), "UPDATE forms SET status = 'archived', updated_at = ? WHERE id = ?", [nowIso(), form.id]);
+    await writeAuditLog(requestDb(c), "admin", admin.id, "form_archived", "form", form.id, { key: form.key });
     return json({ success: true, action: "archived", message: "Form archived — submissions preserved." });
   }
 
-  await run(c.env.DB, "DELETE FROM form_fields WHERE form_id = ?", [form.id]);
-  await run(c.env.DB, "DELETE FROM forms WHERE id = ?", [form.id]);
-  await writeAuditLog(c.env.DB, "admin", admin.id, "form_deleted", "form", form.id, { key: form.key });
+  await run(requestDb(c), "DELETE FROM form_fields WHERE form_id = ?", [form.id]);
+  await run(requestDb(c), "DELETE FROM forms WHERE id = ?", [form.id]);
+  await writeAuditLog(requestDb(c), "admin", admin.id, "form_deleted", "form", form.id, { key: form.key });
   return json({ success: true, action: "deleted" });
 }
 
 export class AdminFormsFormKeyGet extends OpenAPIRoute {
   schema = {};
 
-  async handle(c: any) {
+  async handle(c: AdminContext) {
     try {
       return await onRequestGet(c);
     } catch (error) {
@@ -173,7 +174,7 @@ export class AdminFormsFormKeyGet extends OpenAPIRoute {
 export class AdminFormsFormKeyPatch extends OpenAPIRoute {
   schema = {};
 
-  async handle(c: any) {
+  async handle(c: AdminContext) {
     try {
       return await onRequestPatch(c);
     } catch (error) {
@@ -185,7 +186,7 @@ export class AdminFormsFormKeyPatch extends OpenAPIRoute {
 export class AdminFormsFormKeyDelete extends OpenAPIRoute {
   schema = {};
 
-  async handle(c: any) {
+  async handle(c: AdminContext) {
     try {
       return await onRequestDelete(c);
     } catch (error) {

--- a/functions/api/v1/admin/forms/[formKey]/router.ts
+++ b/functions/api/v1/admin/forms/[formKey]/router.ts
@@ -4,8 +4,9 @@ import { AdminFormsFormKeyGet } from "./index";
 import { AdminFormsFormKeyPatch } from "./index";
 import { AdminFormsFormKeyDelete } from "./index";
 import { onRequestGet as AdminFormsFormKeySubmissionsGet_l } from "./submissions";
+import type { RequestDbContext } from "../../../../../_lib/db/context";
 
-const app = new Hono();
+const app = new Hono<RequestDbContext>();
 export const openapi = fromHono(app);
 
 openapi.get("/", AdminFormsFormKeyGet);

--- a/functions/api/v1/admin/forms/[formKey]/submissions.ts
+++ b/functions/api/v1/admin/forms/[formKey]/submissions.ts
@@ -9,6 +9,7 @@ import { requireAdminFromRequest } from "../../../../../_lib/auth/admin";
 import { all, first } from "../../../../../_lib/db/queries";
 import { parseJsonSafe } from "../../../../../_lib/utils/json";
 import { AppError } from "../../../../../_lib/errors";
+import { requestDb, type AdminContext } from "../../../../../_lib/db/context";
 
 interface FormRow {
   id: string;
@@ -35,12 +36,12 @@ interface AnswerRow {
   data_json: string | null;
 }
 
-export async function onRequestGet(c: any): Promise<Response> {
-  await requireAdminFromRequest(c.env.DB, c.req.raw, c.env);
+export async function onRequestGet(c: AdminContext): Promise<Response> {
+  await requireAdminFromRequest(requestDb(c), c.req.raw, c.env);
 
   const formKey = c.req.param("formKey");
 
-  const form = await first<FormRow>(c.env.DB, "SELECT id, key, title, purpose FROM forms WHERE key = ?", [formKey]);
+  const form = await first<FormRow>(requestDb(c), "SELECT id, key, title, purpose FROM forms WHERE key = ?", [formKey]);
   if (!form) throw new AppError(404, "FORM_NOT_FOUND", `Form '${formKey}' not found`);
 
   const url = new URL(c.req.raw.url);
@@ -54,7 +55,7 @@ export async function onRequestGet(c: any): Promise<Response> {
   params.push(limit, offset);
 
   const submissions = await all<SubmissionRow>(
-    c.env.DB,
+    requestDb(c),
     `SELECT
        fs.id, fs.form_id, fs.submitted_by_user_id, fs.context_type, fs.context_ref,
        fs.status, fs.submitted_at,
@@ -76,7 +77,7 @@ export async function onRequestGet(c: any): Promise<Response> {
   const submissionIds = submissions.map((s) => s.id);
   const placeholders = submissionIds.map(() => "?").join(",");
   const answers = await all<AnswerRow>(
-    c.env.DB,
+    requestDb(c),
     `SELECT submission_id, field_key, data_json
      FROM form_submission_answers
      WHERE submission_id IN (${placeholders})
@@ -119,7 +120,7 @@ export async function onRequestGet(c: any): Promise<Response> {
   });
 }
 
-export async function onRequest(c: any): Promise<Response> {
+export async function onRequest(c: AdminContext): Promise<Response> {
   if (c.req.raw.method === "GET") return onRequestGet(c);
   return json({ error: { code: "METHOD_NOT_ALLOWED", message: "Method not allowed" } }, 405);
 }

--- a/functions/api/v1/admin/forms/router.ts
+++ b/functions/api/v1/admin/forms/router.ts
@@ -1,8 +1,9 @@
 import { Hono } from "hono";
 import { fromHono } from "chanfana";
 import formKey_Router from "./[formKey]/router";
+import type { RequestDbContext } from "../../../../_lib/db/context";
 
-const app = new Hono();
+const app = new Hono<RequestDbContext>();
 export const openapi = fromHono(app);
 
 app.route("/:formKey", formKey_Router);

--- a/functions/api/v1/admin/proposals/[proposalId]/audit-log.ts
+++ b/functions/api/v1/admin/proposals/[proposalId]/audit-log.ts
@@ -2,6 +2,7 @@ import { json } from "../../../../../_lib/http";
 import { requireAdminFromRequest } from "../../../../../_lib/auth/admin";
 import { first, all } from "../../../../../_lib/db/queries";
 import type { DatabaseLike } from "../../../../../_lib/types";
+import { requestDb, type AdminContext } from "../../../../../_lib/db/context";
 
 interface AuditLogRow {
   id: string;
@@ -41,16 +42,18 @@ async function fetchAuditLog(db: DatabaseLike, proposalId: string): Promise<Audi
   );
 }
 
-export async function onRequestGet(c: any): Promise<Response> {
-  await requireAdminFromRequest(c.env.DB, c.req.raw, c.env);
+export async function onRequestGet(c: AdminContext): Promise<Response> {
+  await requireAdminFromRequest(requestDb(c), c.req.raw, c.env);
   const proposalId = c.req.param("proposalId");
 
-  const proposal = await first<{ id: string }>(c.env.DB, "SELECT id FROM session_proposals WHERE id = ?", [proposalId]);
+  const proposal = await first<{ id: string }>(requestDb(c), "SELECT id FROM session_proposals WHERE id = ?", [
+    proposalId,
+  ]);
   if (!proposal) {
     return json({ error: { code: "PROPOSAL_NOT_FOUND", message: "Proposal not found" } }, 404);
   }
 
-  const entries = await fetchAuditLog(c.env.DB, proposalId);
+  const entries = await fetchAuditLog(requestDb(c), proposalId);
 
   const parsed = entries.map((e) => ({
     ...e,

--- a/functions/api/v1/admin/proposals/[proposalId]/finalize-preview.ts
+++ b/functions/api/v1/admin/proposals/[proposalId]/finalize-preview.ts
@@ -10,13 +10,14 @@ import { loadEmailLayout, loadEmailPartials } from "../../../../../_lib/email/pa
 import { proposalManagePageUrl, speakerManagePageUrl } from "../../../../../_lib/services/frontend-links";
 import { finalizeProposalSchema } from "../../../../../../assets/shared/schemas/api";
 import { buildProposalDecisionEmailPlan } from "./decision-emails";
+import { requestDb, type AdminContext } from "../../../../../_lib/db/context";
 
-export async function onRequestPost(c: any): Promise<Response> {
-  const admin = await requireAdminFromRequest(c.env.DB, c.req.raw);
+export async function onRequestPost(c: AdminContext): Promise<Response> {
+  const admin = await requireAdminFromRequest(requestDb(c), c.req.raw, c.env);
   const proposalId = c.req.param("proposalId");
 
   const accessCheckProposal = await first<{ event_id: string }>(
-    c.env.DB,
+    requestDb(c),
     "SELECT event_id FROM session_proposals WHERE id = ?",
     [proposalId],
   );
@@ -24,7 +25,7 @@ export async function onRequestPost(c: any): Promise<Response> {
     return json({ error: { code: "PROPOSAL_NOT_FOUND", message: "Proposal not found" } }, 404);
   }
 
-  const access = await getProposalAccessForEvent(c.env.DB, accessCheckProposal.event_id, admin);
+  const access = await getProposalAccessForEvent(requestDb(c), accessCheckProposal.event_id, admin);
   if (!access.canFinalize) {
     return json({ error: { code: "FORBIDDEN", message: "Missing permission to finalize proposals" } }, 403);
   }
@@ -32,7 +33,7 @@ export async function onRequestPost(c: any): Promise<Response> {
   const body = await parseJsonBody(c.req, finalizeProposalSchema);
   const appBaseUrl = resolveAppBaseUrl(c.env, c.req.raw);
   const plan = await buildProposalDecisionEmailPlan(
-    c.env.DB,
+    requestDb(c),
     {
       proposalId,
       finalStatus: body.finalStatus,
@@ -48,11 +49,11 @@ export async function onRequestPost(c: any): Promise<Response> {
     },
   );
 
-  const [layoutHtml, partials] = await Promise.all([loadEmailLayout(c.env.DB), loadEmailPartials(c.env.DB)]);
+  const [layoutHtml, partials] = await Promise.all([loadEmailLayout(requestDb(c)), loadEmailPartials(requestDb(c))]);
 
   const messages = await Promise.all(
     plan.messages.map(async (message) => {
-      const template = await resolveTemplate(c.env.DB, message.templateKey);
+      const template = await resolveTemplate(requestDb(c), message.templateKey);
       const dataWithPartials = { ...message.data, _partials: partials };
       const subject = renderSubject(template.subjectTemplate, message.fallbackSubject, dataWithPartials);
       const rendered = await renderEmail(
@@ -83,7 +84,7 @@ export async function onRequestPost(c: any): Promise<Response> {
   });
 }
 
-export async function onRequest(c: any): Promise<Response> {
+export async function onRequest(c: AdminContext): Promise<Response> {
   if (c.req.raw.method !== "POST") {
     return json({ error: { code: "METHOD_NOT_ALLOWED", message: "Method not allowed" } }, 405);
   }

--- a/functions/api/v1/admin/proposals/[proposalId]/finalize.ts
+++ b/functions/api/v1/admin/proposals/[proposalId]/finalize.ts
@@ -10,13 +10,14 @@ import { proposalManagePageUrl, speakerManagePageUrl } from "../../../../../_lib
 import { writeAuditLog } from "../../../../../_lib/services/audit";
 import { finalizeProposalSchema } from "../../../../../../assets/shared/schemas/api";
 import { buildProposalDecisionEmailPlan } from "./decision-emails";
+import { requestDb, type AdminContext } from "../../../../../_lib/db/context";
 
-export async function onRequestPost(c: any): Promise<Response> {
-  const admin = await requireAdminFromRequest(c.env.DB, c.req.raw);
+export async function onRequestPost(c: AdminContext): Promise<Response> {
+  const admin = await requireAdminFromRequest(requestDb(c), c.req.raw, c.env);
   const proposalId = c.req.param("proposalId");
 
   const accessCheckProposal = await first<{ event_id: string }>(
-    c.env.DB,
+    requestDb(c),
     "SELECT event_id FROM session_proposals WHERE id = ?",
     [proposalId],
   );
@@ -24,7 +25,7 @@ export async function onRequestPost(c: any): Promise<Response> {
     return json({ error: { code: "PROPOSAL_NOT_FOUND", message: "Proposal not found" } }, 404);
   }
 
-  const access = await getProposalAccessForEvent(c.env.DB, accessCheckProposal.event_id, admin);
+  const access = await getProposalAccessForEvent(requestDb(c), accessCheckProposal.event_id, admin);
   if (!access.canFinalize) {
     return json({ error: { code: "FORBIDDEN", message: "Missing permission to finalize proposals" } }, 403);
   }
@@ -32,7 +33,7 @@ export async function onRequestPost(c: any): Promise<Response> {
   const body = await parseJsonBody(c.req, finalizeProposalSchema);
   const config = getConfig(c.env, c.req.raw);
   const previousDecision = await first<{ final_status: string | null; decision_note: string | null }>(
-    c.env.DB,
+    requestDb(c),
     `SELECT final_status, decision_note
      FROM proposal_decisions
      WHERE proposal_id = ?
@@ -43,7 +44,7 @@ export async function onRequestPost(c: any): Promise<Response> {
 
   const minReviewsRequired = config.minProposalReviews;
 
-  const finalized = await finalizeProposalDecision(c.env.DB, {
+  const finalized = await finalizeProposalDecision(requestDb(c), {
     proposalId,
     decidedByUserId: admin.id,
     finalStatus: body.finalStatus,
@@ -54,7 +55,7 @@ export async function onRequestPost(c: any): Promise<Response> {
   // Store the presentation deadline on the proposal when accepting.
   if (body.finalStatus === "accepted" && body.presentationDeadline) {
     await run(
-      c.env.DB,
+      requestDb(c),
       "UPDATE session_proposals SET presentation_deadline = ?, updated_at = datetime('now') WHERE id = ?",
       [body.presentationDeadline, proposalId],
     );
@@ -62,7 +63,7 @@ export async function onRequestPost(c: any): Promise<Response> {
 
   const appBaseUrl = resolveAppBaseUrl(c.env, c.req.raw);
   const plan = await buildProposalDecisionEmailPlan(
-    c.env.DB,
+    requestDb(c),
     {
       proposalId,
       finalStatus: body.finalStatus,
@@ -79,7 +80,7 @@ export async function onRequestPost(c: any): Promise<Response> {
   );
 
   for (const message of plan.messages) {
-    await queueEmail(c.env.DB, {
+    await queueEmail(requestDb(c), {
       eventId: plan.proposal.event_id,
       templateKey: message.templateKey,
       recipientEmail: message.recipientEmail,
@@ -89,7 +90,7 @@ export async function onRequestPost(c: any): Promise<Response> {
       data: message.data,
     });
 
-    await writeAuditLog(c.env.DB, "admin", admin.id, "proposal_decision_email_queued", "proposal", proposalId, {
+    await writeAuditLog(requestDb(c), "admin", admin.id, "proposal_decision_email_queued", "proposal", proposalId, {
       templateKey: { from: null, to: message.templateKey },
       recipientEmail: { from: null, to: message.recipientEmail },
       recipientUserId: { from: null, to: message.recipientUserId },
@@ -98,7 +99,7 @@ export async function onRequestPost(c: any): Promise<Response> {
 
   for (const userId of plan.presentationReminderUserIds) {
     await run(
-      c.env.DB,
+      requestDb(c),
       `UPDATE proposal_speakers
        SET presentation_last_communication_at = ?,
            presentation_reminders_paused_until = NULL
@@ -107,7 +108,7 @@ export async function onRequestPost(c: any): Promise<Response> {
     );
   }
 
-  await writeAuditLog(c.env.DB, "admin", admin.id, "proposal_decision_recorded", "proposal", proposalId, {
+  await writeAuditLog(requestDb(c), "admin", admin.id, "proposal_decision_recorded", "proposal", proposalId, {
     adminEmail: { from: null, to: admin.email },
     finalStatus: { from: previousDecision?.final_status ?? null, to: body.finalStatus },
     decisionNote: { from: previousDecision?.decision_note ?? null, to: body.decisionNote ?? null },
@@ -118,7 +119,7 @@ export async function onRequestPost(c: any): Promise<Response> {
   return json({ success: true, ...finalized, minReviewsRequired });
 }
 
-export async function onRequest(c: any): Promise<Response> {
+export async function onRequest(c: AdminContext): Promise<Response> {
   if (c.req.raw.method !== "POST") {
     return json({ error: { code: "METHOD_NOT_ALLOWED", message: "Method not allowed" } }, 405);
   }

--- a/functions/api/v1/admin/proposals/[proposalId]/index.ts
+++ b/functions/api/v1/admin/proposals/[proposalId]/index.ts
@@ -12,13 +12,14 @@ import { getConfig } from "../../../../../_lib/config";
 import { getActiveFormByPurpose } from "../../../../../_lib/services/forms";
 import { parseJsonSafe } from "../../../../../_lib/utils/json";
 import type { ProposalListRecord } from "../../../../../_lib/services/proposals";
+import { requestDb, type AdminContext } from "../../../../../_lib/db/context";
 
-export async function onRequestGet(c: any): Promise<Response> {
-  const admin = await requireAdminFromRequest(c.env.DB, c.req.raw);
+export async function onRequestGet(c: AdminContext): Promise<Response> {
+  const admin = await requireAdminFromRequest(requestDb(c), c.req.raw, c.env);
   const proposalId = c.req.param("proposalId");
 
   const proposal = await first<ProposalListRecord>(
-    c.env.DB,
+    requestDb(c),
     `SELECT
        sp.*,
        u.email      AS proposer_email,
@@ -44,9 +45,9 @@ export async function onRequestGet(c: any): Promise<Response> {
     return json({ error: { code: "PROPOSAL_NOT_FOUND", message: "Proposal not found" } }, 404);
   }
 
-  const access = await getProposalAccessForEvent(c.env.DB, proposal.event_id, admin);
+  const access = await getProposalAccessForEvent(requestDb(c), proposal.event_id, admin);
   const config = getConfig(c.env, c.req.raw);
-  const proposalForm = await getActiveFormByPurpose(c.env.DB, proposal.event_id, "proposal_submission");
+  const proposalForm = await getActiveFormByPurpose(requestDb(c), proposal.event_id, "proposal_submission");
 
   return json({
     proposal: {

--- a/functions/api/v1/admin/proposals/[proposalId]/open-manage.ts
+++ b/functions/api/v1/admin/proposals/[proposalId]/open-manage.ts
@@ -12,9 +12,10 @@ import { json } from "../../../../../_lib/http";
 import { writeAuditLog } from "../../../../../_lib/services/audit";
 import { proposalManagePageUrl } from "../../../../../_lib/services/frontend-links";
 import { refreshProposalManageToken } from "../../../../../_lib/services/proposals";
+import { requestDb, type AdminContext } from "../../../../../_lib/db/context";
 
-export async function onRequestPost(c: any): Promise<Response> {
-  const admin = await requireAdminFromRequest(c.env.DB, c.req.raw);
+export async function onRequestPost(c: AdminContext): Promise<Response> {
+  const admin = await requireAdminFromRequest(requestDb(c), c.req.raw, c.env);
   const proposalId = c.req.param("proposalId");
 
   const proposal = await first<{
@@ -25,7 +26,7 @@ export async function onRequestPost(c: any): Promise<Response> {
     starts_at: string | null;
     settings_json: string;
   }>(
-    c.env.DB,
+    requestDb(c),
     `SELECT
        sp.id,
        sp.event_id,
@@ -43,16 +44,16 @@ export async function onRequestPost(c: any): Promise<Response> {
     return json({ error: { code: "PROPOSAL_NOT_FOUND", message: "Proposal not found" } }, 404);
   }
 
-  const access = await getProposalAccessForEvent(c.env.DB, proposal.event_id, admin);
+  const access = await getProposalAccessForEvent(requestDb(c), proposal.event_id, admin);
   if (!access.canReview) {
     return json({ error: { code: "FORBIDDEN", message: "Missing permission to manage proposals" } }, 403);
   }
 
-  const token = await refreshProposalManageToken(c.env.DB, proposalId);
+  const token = await refreshProposalManageToken(requestDb(c), proposalId);
   const appBaseUrl = resolveAppBaseUrl(c.env, c.req.raw);
   const manageUrl = proposalManagePageUrl(appBaseUrl, proposal, token);
 
-  await writeAuditLog(c.env.DB, "admin", admin.id, "admin_opened_proposal_manage_page", "proposal", proposalId, {
+  await writeAuditLog(requestDb(c), "admin", admin.id, "admin_opened_proposal_manage_page", "proposal", proposalId, {
     adminEmail: admin.email,
     eventSlug: proposal.slug,
   });

--- a/functions/api/v1/admin/proposals/[proposalId]/patch.ts
+++ b/functions/api/v1/admin/proposals/[proposalId]/patch.ts
@@ -13,13 +13,14 @@ import { getProposalAccessForEvent } from "../../../../../_lib/auth/proposal-acc
 import { first, run } from "../../../../../_lib/db/queries";
 import { writeAuditLog } from "../../../../../_lib/services/audit";
 import { adminProposalPatchSchema } from "../../../../../../assets/shared/schemas/api";
+import { requestDb, type AdminContext } from "../../../../../_lib/db/context";
 
-export async function onRequestPatch(c: any): Promise<Response> {
-  const admin = await requireAdminFromRequest(c.env.DB, c.req.raw);
+export async function onRequestPatch(c: AdminContext): Promise<Response> {
+  const admin = await requireAdminFromRequest(requestDb(c), c.req.raw, c.env);
   const proposalId = c.req.param("proposalId");
 
   const proposal = await first<{ id: string; event_id: string; title: string; abstract: string }>(
-    c.env.DB,
+    requestDb(c),
     "SELECT id, event_id, title, abstract FROM session_proposals WHERE id = ?",
     [proposalId],
   );
@@ -27,7 +28,7 @@ export async function onRequestPatch(c: any): Promise<Response> {
     return json({ error: { code: "PROPOSAL_NOT_FOUND", message: "Proposal not found" } }, 404);
   }
 
-  const access = await getProposalAccessForEvent(c.env.DB, proposal.event_id, admin);
+  const access = await getProposalAccessForEvent(requestDb(c), proposal.event_id, admin);
   if (!access.canFinalize) {
     return json({ error: { code: "FORBIDDEN", message: "Missing permission to edit proposals" } }, 403);
   }
@@ -35,7 +36,7 @@ export async function onRequestPatch(c: any): Promise<Response> {
   const body = await parseJsonBody(c.req, adminProposalPatchSchema);
 
   await run(
-    c.env.DB,
+    requestDb(c),
     `UPDATE session_proposals
      SET title    = COALESCE(?, title),
          abstract = COALESCE(?, abstract),
@@ -45,7 +46,7 @@ export async function onRequestPatch(c: any): Promise<Response> {
   );
 
   const updated = await first<{ id: string; title: string; abstract: string; updated_at: string }>(
-    c.env.DB,
+    requestDb(c),
     "SELECT id, title, abstract, updated_at FROM session_proposals WHERE id = ?",
     [proposalId],
   );
@@ -62,7 +63,7 @@ export async function onRequestPatch(c: any): Promise<Response> {
   }
 
   if (Object.keys(changes).length > 0) {
-    await writeAuditLog(c.env.DB, "admin", admin.id, "proposal_edited", "proposal", proposalId, changes);
+    await writeAuditLog(requestDb(c), "admin", admin.id, "proposal_edited", "proposal", proposalId, changes);
   }
 
   return json({ proposal: updated });

--- a/functions/api/v1/admin/proposals/[proposalId]/reviews.ts
+++ b/functions/api/v1/admin/proposals/[proposalId]/reviews.ts
@@ -10,37 +10,42 @@ import {
 import { writeAuditLog } from "../../../../../_lib/services/audit";
 import { first } from "../../../../../_lib/db/queries";
 import { reviewUpsertSchema } from "../../../../../../assets/shared/schemas/api";
+import { requestDb, type AdminContext } from "../../../../../_lib/db/context";
 
-export async function onRequestGet(c: any): Promise<Response> {
-  const admin = await requireAdminFromRequest(c.env.DB, c.req.raw);
+export async function onRequestGet(c: AdminContext): Promise<Response> {
+  const admin = await requireAdminFromRequest(requestDb(c), c.req.raw, c.env);
   const proposalId = c.req.param("proposalId");
-  const proposal = await first<{ event_id: string }>(c.env.DB, "SELECT event_id FROM session_proposals WHERE id = ?", [
-    proposalId,
-  ]);
+  const proposal = await first<{ event_id: string }>(
+    requestDb(c),
+    "SELECT event_id FROM session_proposals WHERE id = ?",
+    [proposalId],
+  );
   if (!proposal) {
     return json({ error: { code: "PROPOSAL_NOT_FOUND", message: "Proposal not found" } }, 404);
   }
 
-  const access = await getProposalAccessForEvent(c.env.DB, proposal.event_id, admin);
+  const access = await getProposalAccessForEvent(requestDb(c), proposal.event_id, admin);
   if (!access.canReview) {
     return json({ error: { code: "FORBIDDEN", message: "Missing permission to review proposals" } }, 403);
   }
 
-  const reviews = await listProposalReviews(c.env.DB, proposalId);
+  const reviews = await listProposalReviews(requestDb(c), proposalId);
   return json({ proposalId, reviews });
 }
 
-export async function onRequestPost(c: any): Promise<Response> {
-  const admin = await requireAdminFromRequest(c.env.DB, c.req.raw);
+export async function onRequestPost(c: AdminContext): Promise<Response> {
+  const admin = await requireAdminFromRequest(requestDb(c), c.req.raw, c.env);
   const proposalId = c.req.param("proposalId");
-  const proposal = await first<{ event_id: string }>(c.env.DB, "SELECT event_id FROM session_proposals WHERE id = ?", [
-    proposalId,
-  ]);
+  const proposal = await first<{ event_id: string }>(
+    requestDb(c),
+    "SELECT event_id FROM session_proposals WHERE id = ?",
+    [proposalId],
+  );
   if (!proposal) {
     return json({ error: { code: "PROPOSAL_NOT_FOUND", message: "Proposal not found" } }, 404);
   }
 
-  const access = await getProposalAccessForEvent(c.env.DB, proposal.event_id, admin);
+  const access = await getProposalAccessForEvent(requestDb(c), proposal.event_id, admin);
   if (!access.canReview) {
     return json({ error: { code: "FORBIDDEN", message: "Missing permission to review proposals" } }, 403);
   }
@@ -53,14 +58,14 @@ export async function onRequestPost(c: any): Promise<Response> {
     reviewer_comment: string | null;
     applicant_note: string | null;
   }>(
-    c.env.DB,
+    requestDb(c),
     `SELECT id, recommendation, score, reviewer_comment, applicant_note
      FROM proposal_reviews
      WHERE proposal_id = ? AND reviewer_user_id = ?`,
     [proposalId, admin.id],
   );
 
-  const review = await upsertProposalReview(c.env.DB, {
+  const review = await upsertProposalReview(requestDb(c), {
     proposalId,
     reviewerUserId: admin.id,
     recommendation: body.recommendation,
@@ -84,13 +89,21 @@ export async function onRequestPost(c: any): Promise<Response> {
 
   const changes = buildProposalReviewAuditDetails(before, after);
   if (Object.keys(changes).length > 0) {
-    await writeAuditLog(c.env.DB, "admin", admin.id, "proposal_review_upserted", "proposal_review", review.id, changes);
+    await writeAuditLog(
+      requestDb(c),
+      "admin",
+      admin.id,
+      "proposal_review_upserted",
+      "proposal_review",
+      review.id,
+      changes,
+    );
   }
 
   return json({ success: true, review });
 }
 
-export async function onRequest(c: any): Promise<Response> {
+export async function onRequest(c: AdminContext): Promise<Response> {
   if (c.req.raw.method === "GET") {
     return onRequestGet(c);
   }

--- a/functions/api/v1/admin/proposals/[proposalId]/reviews/[reviewId].ts
+++ b/functions/api/v1/admin/proposals/[proposalId]/reviews/[reviewId].ts
@@ -6,26 +6,29 @@ import { first } from "../../../../../../_lib/db/queries";
 import { writeAuditLog } from "../../../../../../_lib/services/audit";
 import { buildProposalReviewAuditDetails, updateReviewById } from "../../../../../../_lib/services/proposals";
 import { reviewPatchSchema } from "../../../../../../../assets/shared/schemas/api";
+import { requestDb, type AdminContext } from "../../../../../../_lib/db/context";
 
-export async function onRequestPatch(c: any): Promise<Response> {
-  const admin = await requireAdminFromRequest(c.env.DB, c.req.raw);
+export async function onRequestPatch(c: AdminContext): Promise<Response> {
+  const admin = await requireAdminFromRequest(requestDb(c), c.req.raw, c.env);
   const proposalId = c.req.param("proposalId");
   const reviewId = c.req.param("reviewId");
 
-  const proposal = await first<{ event_id: string }>(c.env.DB, "SELECT event_id FROM session_proposals WHERE id = ?", [
-    proposalId,
-  ]);
+  const proposal = await first<{ event_id: string }>(
+    requestDb(c),
+    "SELECT event_id FROM session_proposals WHERE id = ?",
+    [proposalId],
+  );
   if (!proposal) {
     return json({ error: { code: "PROPOSAL_NOT_FOUND", message: "Proposal not found" } }, 404);
   }
 
-  const access = await getProposalAccessForEvent(c.env.DB, proposal.event_id, admin);
+  const access = await getProposalAccessForEvent(requestDb(c), proposal.event_id, admin);
   if (!access.canReview) {
     return json({ error: { code: "FORBIDDEN", message: "Missing permission to review proposals" } }, 403);
   }
 
   const reviewBelongsToProposal = await first<{ id: string }>(
-    c.env.DB,
+    requestDb(c),
     "SELECT id FROM proposal_reviews WHERE id = ? AND proposal_id = ?",
     [reviewId, proposalId],
   );
@@ -41,14 +44,14 @@ export async function onRequestPatch(c: any): Promise<Response> {
     reviewer_comment: string | null;
     applicant_note: string | null;
   }>(
-    c.env.DB,
+    requestDb(c),
     `SELECT recommendation, score, reviewer_comment, applicant_note
      FROM proposal_reviews
      WHERE id = ?`,
     [reviewId],
   );
 
-  const review = await updateReviewById(c.env.DB, reviewId, body);
+  const review = await updateReviewById(requestDb(c), reviewId, body);
 
   if (existing) {
     const changes = buildProposalReviewAuditDetails(
@@ -68,7 +71,7 @@ export async function onRequestPatch(c: any): Promise<Response> {
 
     if (Object.keys(changes).length > 0) {
       await writeAuditLog(
-        c.env.DB,
+        requestDb(c),
         "admin",
         admin.id,
         "proposal_review_upserted",
@@ -82,7 +85,7 @@ export async function onRequestPatch(c: any): Promise<Response> {
   return json({ success: true, review });
 }
 
-export async function onRequest(c: any): Promise<Response> {
+export async function onRequest(c: AdminContext): Promise<Response> {
   if (c.req.raw.method !== "PATCH") {
     return json({ error: { code: "METHOD_NOT_ALLOWED", message: "Method not allowed" } }, 405);
   }

--- a/functions/api/v1/admin/proposals/[proposalId]/reviews/router.ts
+++ b/functions/api/v1/admin/proposals/[proposalId]/reviews/router.ts
@@ -1,8 +1,9 @@
 import { Hono } from "hono";
 import { fromHono } from "chanfana";
 import { onRequestPatch as AdminProposalsProposalIdReviewsReviewIdPatch_l } from "./[reviewId]";
+import type { RequestDbContext } from "../../../../../../_lib/db/context";
 
-const app = new Hono();
+const app = new Hono<RequestDbContext>();
 export const openapi = fromHono(app);
 
 app.patch("/:reviewId", AdminProposalsProposalIdReviewsReviewIdPatch_l);

--- a/functions/api/v1/admin/proposals/[proposalId]/router.ts
+++ b/functions/api/v1/admin/proposals/[proposalId]/router.ts
@@ -11,8 +11,9 @@ import { onRequestPost as AdminProposalsProposalIdReviewsPost_l } from "./review
 import { onRequestGet as AdminProposalsProposalIdSpeakersGet_l } from "./speakers";
 import reviews_Router from "./reviews/router";
 import speakers_Router from "./speakers/router";
+import type { RequestDbContext } from "../../../../../_lib/db/context";
 
-const app = new Hono();
+const app = new Hono<RequestDbContext>();
 export const openapi = fromHono(app);
 
 app.get("/", AdminProposalsProposalIdGet_l);

--- a/functions/api/v1/admin/proposals/[proposalId]/speakers.ts
+++ b/functions/api/v1/admin/proposals/[proposalId]/speakers.ts
@@ -15,9 +15,10 @@ import { getProposalAccessForEvent } from "../../../../../_lib/auth/proposal-acc
 import { listProposalSpeakersWithStatus } from "../../../../../_lib/services/proposals";
 import { resolveAppBaseUrl } from "../../../../../_lib/config";
 import { first } from "../../../../../_lib/db/queries";
+import { requestDb, type AdminContext } from "../../../../../_lib/db/context";
 
-export async function onRequestGet(c: any): Promise<Response> {
-  const admin = await requireAdminFromRequest(c.env.DB, c.req.raw);
+export async function onRequestGet(c: AdminContext): Promise<Response> {
+  const admin = await requireAdminFromRequest(requestDb(c), c.req.raw, c.env);
   const proposalId = c.req.param("proposalId");
 
   const proposal = await first<{
@@ -29,7 +30,7 @@ export async function onRequestGet(c: any): Promise<Response> {
     presentation_r2_key: string | null;
     presentation_uploaded_at: string | null;
   }>(
-    c.env.DB,
+    requestDb(c),
     `SELECT id, title, status, event_id,
             presentation_deadline, presentation_r2_key, presentation_uploaded_at
      FROM session_proposals WHERE id = ?`,
@@ -40,12 +41,12 @@ export async function onRequestGet(c: any): Promise<Response> {
     return json({ error: { code: "PROPOSAL_NOT_FOUND", message: "Proposal not found" } }, 404);
   }
 
-  const access = await getProposalAccessForEvent(c.env.DB, proposal.event_id, admin);
+  const access = await getProposalAccessForEvent(requestDb(c), proposal.event_id, admin);
   if (!access.canReview) {
     return json({ error: { code: "FORBIDDEN", message: "Missing permission to review proposals" } }, 403);
   }
 
-  const speakers = await listProposalSpeakersWithStatus(c.env.DB, proposalId);
+  const speakers = await listProposalSpeakersWithStatus(requestDb(c), proposalId);
   const appBaseUrl = resolveAppBaseUrl(c.env, c.req.raw);
 
   // Summarise participation completeness for the admin overview.
@@ -98,7 +99,7 @@ export async function onRequestGet(c: any): Promise<Response> {
   });
 }
 
-export async function onRequest(c: any): Promise<Response> {
+export async function onRequest(c: AdminContext): Promise<Response> {
   if (c.req.raw.method !== "GET") {
     return json({ error: { code: "METHOD_NOT_ALLOWED", message: "Method not allowed" } }, 405);
   }

--- a/functions/api/v1/admin/proposals/[proposalId]/speakers/[userId].ts
+++ b/functions/api/v1/admin/proposals/[proposalId]/speakers/[userId].ts
@@ -13,26 +13,29 @@ import { updateSpeakerProfile } from "../../../../../../_lib/services/proposals-
 import { first } from "../../../../../../_lib/db/queries";
 import { writeAuditLog } from "../../../../../../_lib/services/audit";
 import { adminSpeakerBioPatchSchema } from "../../../../../../../assets/shared/schemas/api";
+import { requestDb, type AdminContext } from "../../../../../../_lib/db/context";
 
-export async function onRequestPatch(c: any): Promise<Response> {
-  const admin = await requireAdminFromRequest(c.env.DB, c.req.raw);
+export async function onRequestPatch(c: AdminContext): Promise<Response> {
+  const admin = await requireAdminFromRequest(requestDb(c), c.req.raw, c.env);
   const proposalId = c.req.param("proposalId");
   const userId = c.req.param("userId");
 
-  const proposal = await first<{ event_id: string }>(c.env.DB, "SELECT event_id FROM session_proposals WHERE id = ?", [
-    proposalId,
-  ]);
+  const proposal = await first<{ event_id: string }>(
+    requestDb(c),
+    "SELECT event_id FROM session_proposals WHERE id = ?",
+    [proposalId],
+  );
   if (!proposal) {
     return json({ error: { code: "PROPOSAL_NOT_FOUND", message: "Proposal not found" } }, 404);
   }
 
-  const access = await getProposalAccessForEvent(c.env.DB, proposal.event_id, admin);
+  const access = await getProposalAccessForEvent(requestDb(c), proposal.event_id, admin);
   if (!access.canReview) {
     return json({ error: { code: "FORBIDDEN", message: "Missing permission to edit speaker profiles" } }, 403);
   }
 
   const speaker = await first<{ user_id: string }>(
-    c.env.DB,
+    requestDb(c),
     "SELECT user_id FROM proposal_speakers WHERE proposal_id = ? AND user_id = ?",
     [proposalId, userId],
   );
@@ -41,9 +44,9 @@ export async function onRequestPatch(c: any): Promise<Response> {
   }
 
   const body = await parseJsonBody(c.req, adminSpeakerBioPatchSchema);
-  await updateSpeakerProfile(c.env.DB, userId, { biography: body.biography ?? undefined });
+  await updateSpeakerProfile(requestDb(c), userId, { biography: body.biography ?? undefined });
 
-  await writeAuditLog(c.env.DB, "admin", admin.id, "speaker_bio_updated", "proposal", proposalId, {
+  await writeAuditLog(requestDb(c), "admin", admin.id, "speaker_bio_updated", "proposal", proposalId, {
     speakerUserId: userId,
     adminEmail: admin.email,
   });

--- a/functions/api/v1/admin/proposals/[proposalId]/speakers/[userId]/remind.ts
+++ b/functions/api/v1/admin/proposals/[proposalId]/speakers/[userId]/remind.ts
@@ -7,24 +7,25 @@ import { writeAuditLog } from "../../../../../../../_lib/services/audit";
 import { speakerManagePageUrl } from "../../../../../../../_lib/services/frontend-links";
 import { buildEventEmailVariables } from "../../../../../../../_lib/services/events";
 import { first } from "../../../../../../../_lib/db/queries";
+import { requestDb, type AdminContext } from "../../../../../../../_lib/db/context";
 
-export async function onRequestPost(c: any): Promise<Response> {
-  const admin = await requireAdminFromRequest(c.env.DB, c.req.raw, c.env);
+export async function onRequestPost(c: AdminContext): Promise<Response> {
+  const admin = await requireAdminFromRequest(requestDb(c), c.req.raw, c.env);
   const proposalId = c.req.param("proposalId");
   const userId = c.req.param("userId");
 
   const proposal = await first<{ id: string; title: string; event_id: string }>(
-    c.env.DB,
+    requestDb(c),
     "SELECT * FROM session_proposals WHERE id = ?",
     [proposalId],
   );
   if (!proposal) return json({ error: { message: "Proposal not found" } }, 404);
 
-  const event = await first<any>(c.env.DB, "SELECT * FROM events WHERE id = ?", [proposal.event_id]);
+  const event = await first<any>(requestDb(c), "SELECT * FROM events WHERE id = ?", [proposal.event_id]);
   if (!event) return json({ error: { message: "Event not found" } }, 404);
 
   const speaker = await first<any>(
-    c.env.DB,
+    requestDb(c),
     `SELECT
        ps.id AS proposal_speaker_id,
        u.*
@@ -37,10 +38,10 @@ export async function onRequestPost(c: any): Promise<Response> {
 
   const appBaseUrl = resolveAppBaseUrl(c.env, c.req.raw);
 
-  const freshToken = await refreshSpeakerManageToken(c.env.DB, proposalId, userId);
+  const freshToken = await refreshSpeakerManageToken(requestDb(c), proposalId, userId);
   const speakerManageUrl = speakerManagePageUrl(appBaseUrl, event, freshToken);
 
-  await queueEmail(c.env.DB, {
+  await queueEmail(requestDb(c), {
     eventId: event.id,
     templateKey: "speaker_profile_request",
     recipientEmail: speaker.email,
@@ -58,7 +59,7 @@ export async function onRequestPost(c: any): Promise<Response> {
   });
 
   await writeAuditLog(
-    c.env.DB,
+    requestDb(c),
     "admin",
     admin.id,
     "speaker_profile_request_resent",

--- a/functions/api/v1/admin/proposals/[proposalId]/speakers/router.ts
+++ b/functions/api/v1/admin/proposals/[proposalId]/speakers/router.ts
@@ -2,8 +2,9 @@ import { Hono } from "hono";
 import { fromHono } from "chanfana";
 import { onRequestPatch as AdminSpeakerPatch } from "./[userId]";
 import { onRequestPost as AdminSpeakerRemindPost } from "./[userId]/remind";
+import type { RequestDbContext } from "../../../../../../_lib/db/context";
 
-const app = new Hono();
+const app = new Hono<RequestDbContext>();
 export const openapi = fromHono(app);
 
 app.patch("/:userId", AdminSpeakerPatch);

--- a/functions/api/v1/admin/proposals/router.ts
+++ b/functions/api/v1/admin/proposals/router.ts
@@ -1,8 +1,9 @@
 import { Hono } from "hono";
 import { fromHono } from "chanfana";
 import proposalId_Router from "./[proposalId]/router";
+import type { RequestDbContext } from "../../../../_lib/db/context";
 
-const app = new Hono();
+const app = new Hono<RequestDbContext>();
 export const openapi = fromHono(app);
 
 app.route("/:proposalId", proposalId_Router);

--- a/functions/api/v1/admin/router.ts
+++ b/functions/api/v1/admin/router.ts
@@ -1,8 +1,9 @@
-import { Hono } from "hono";
+import { Hono, type Context, type Next } from "hono";
 import { fromHono } from "chanfana";
-import { cacheAdminForRequest, requireAdminFromRequest } from "../../../_lib/auth/admin";
-import { readReplicaDb } from "../../../_lib/db/session";
-import type { Env } from "../../../_lib/types";
+import { getCachedAdminForRequest, requireAdminFromRequest, signAdminSessionToken } from "../../../_lib/auth/admin";
+import { REQUEST_DB_CONTEXT_KEY, type RequestDbContext } from "../../../_lib/db/context";
+import { primaryFirstDb, readReplicaDb } from "../../../_lib/db/session";
+import type { DatabaseSessionLike } from "../../../_lib/db/session";
 import { onRequestGet as AdminAuditLogGet_l } from "./audit-log";
 import { onRequestGet as AdminDonationsGet_l } from "./donations";
 import { onRequestGet as AdminEmailTemplatesGet_l } from "./email-templates";
@@ -19,31 +20,48 @@ import forms_Router from "./forms/router";
 import proposals_Router from "./proposals/router";
 import users_Router from "./users/router";
 
-const app = new Hono();
+const app = new Hono<RequestDbContext>();
 export const openapi = fromHono(app);
+const ADMIN_TOKEN_HEADER = "x-admin-token";
 
-async function useReadReplicaForAdminReads(c: any, next: () => Promise<void>): Promise<void> {
-  const method = c.req.raw.method.toUpperCase();
-  if (method !== "GET" && method !== "HEAD") {
-    await next();
+async function rotateAdminToken(c: Context<RequestDbContext>, sessionDb: DatabaseSessionLike): Promise<void> {
+  const state = sessionDb.getBookmark?.();
+  const admin = getCachedAdminForRequest(c.req.raw);
+  if (!state || !admin?.sessionId || !admin.expiresAt || !c.env.INTERNAL_SIGNING_SECRET) {
     return;
   }
 
-  const env = c.env as Env;
-  const request = c.req.raw as Request;
-  const primaryDb = env.DB;
-  const admin = await requireAdminFromRequest(primaryDb, request, env);
-  cacheAdminForRequest(request, admin);
-
-  env.DB = readReplicaDb(primaryDb);
-  try {
-    await next();
-  } finally {
-    env.DB = primaryDb;
-  }
+  const token = await signAdminSessionToken(c.env.INTERNAL_SIGNING_SECRET, {
+    admin,
+    sessionId: admin.sessionId,
+    expiresAt: admin.expiresAt,
+    state,
+  });
+  c.header(ADMIN_TOKEN_HEADER, token);
 }
 
-app.use("*", useReadReplicaForAdminReads);
+async function useRequestScopedD1Session(c: Context<RequestDbContext>, next: Next): Promise<void> {
+  const method = c.req.method;
+  const primaryDb = c.env.DB;
+
+  if (method !== "GET" && method !== "HEAD") {
+    const sessionDb = primaryFirstDb(primaryDb);
+    c.set(REQUEST_DB_CONTEXT_KEY, sessionDb);
+    await next();
+    await rotateAdminToken(c, sessionDb);
+    return;
+  }
+
+  const admin = await requireAdminFromRequest(primaryDb, c.req.raw, c.env);
+  // Validate state bookmark: must be a reasonable string (null is ok for default session)
+  const bookmark = admin.state ? (admin.state.length > 0 && admin.state.length < 1024 ? admin.state : null) : null;
+  const sessionDb = readReplicaDb(primaryDb, bookmark);
+  c.set(REQUEST_DB_CONTEXT_KEY, sessionDb);
+  await next();
+  await rotateAdminToken(c, sessionDb);
+}
+
+app.use("*", useRequestScopedD1Session);
 
 app.get("/donations", AdminDonationsGet_l);
 app.get("/audit-log", AdminAuditLogGet_l);

--- a/functions/api/v1/admin/router.ts
+++ b/functions/api/v1/admin/router.ts
@@ -1,5 +1,8 @@
 import { Hono } from "hono";
 import { fromHono } from "chanfana";
+import { cacheAdminForRequest, requireAdminFromRequest } from "../../../_lib/auth/admin";
+import { readReplicaDb } from "../../../_lib/db/session";
+import type { Env } from "../../../_lib/types";
 import { onRequestGet as AdminAuditLogGet_l } from "./audit-log";
 import { onRequestGet as AdminDonationsGet_l } from "./donations";
 import { onRequestGet as AdminEmailTemplatesGet_l } from "./email-templates";
@@ -18,6 +21,29 @@ import users_Router from "./users/router";
 
 const app = new Hono();
 export const openapi = fromHono(app);
+
+async function useReadReplicaForAdminReads(c: any, next: () => Promise<void>): Promise<void> {
+  const method = c.req.raw.method.toUpperCase();
+  if (method !== "GET" && method !== "HEAD") {
+    await next();
+    return;
+  }
+
+  const env = c.env as Env;
+  const request = c.req.raw as Request;
+  const primaryDb = env.DB;
+  const admin = await requireAdminFromRequest(primaryDb, request, env);
+  cacheAdminForRequest(request, admin);
+
+  env.DB = readReplicaDb(primaryDb);
+  try {
+    await next();
+  } finally {
+    env.DB = primaryDb;
+  }
+}
+
+app.use("*", useReadReplicaForAdminReads);
 
 app.get("/donations", AdminDonationsGet_l);
 app.get("/audit-log", AdminAuditLogGet_l);

--- a/functions/api/v1/admin/stats.ts
+++ b/functions/api/v1/admin/stats.ts
@@ -1,6 +1,7 @@
 import { json } from "../../../_lib/http";
 import { requireAdminFromRequest } from "../../../_lib/auth/admin";
 import { all, first } from "../../../_lib/db/queries";
+import { requestDb, type AdminContext } from "../../../_lib/db/context";
 
 /**
  * GET /api/v1/admin/stats
@@ -8,10 +9,10 @@ import { all, first } from "../../../_lib/db/queries";
  * Returns aggregate platform stats suitable for dashboards and automated reporting.
  * Supports both session-token auth and ADMIN_API_KEY.
  */
-export async function onRequestGet(c: any): Promise<Response> {
-  await requireAdminFromRequest(c.env.DB, c.req.raw, c.env);
+export async function onRequestGet(c: AdminContext): Promise<Response> {
+  await requireAdminFromRequest(requestDb(c), c.req.raw, c.env);
 
-  const db = c.env.DB;
+  const db = requestDb(c);
 
   const [
     registrationsByStatus,
@@ -261,7 +262,7 @@ export async function onRequestGet(c: any): Promise<Response> {
   });
 }
 
-export async function onRequest(c: any): Promise<Response> {
+export async function onRequest(c: AdminContext): Promise<Response> {
   if (c.req.raw.method !== "GET") {
     return json({ error: { code: "METHOD_NOT_ALLOWED", message: "Method not allowed" } }, 405);
   }

--- a/functions/api/v1/admin/users.ts
+++ b/functions/api/v1/admin/users.ts
@@ -13,6 +13,7 @@
 import { json } from "../../../_lib/http";
 import { requireAdminFromRequest } from "../../../_lib/auth/admin";
 import { all, first } from "../../../_lib/db/queries";
+import { requestDb, type AdminContext } from "../../../_lib/db/context";
 
 interface UserRow {
   id: string;
@@ -25,8 +26,8 @@ interface UserRow {
   created_at: string;
 }
 
-export async function onRequestGet(c: any): Promise<Response> {
-  await requireAdminFromRequest(c.env.DB, c.req.raw, c.env);
+export async function onRequestGet(c: AdminContext): Promise<Response> {
+  await requireAdminFromRequest(requestDb(c), c.req.raw, c.env);
 
   const url = new URL(c.req.raw.url);
   const role = url.searchParams.get("role") ?? "";
@@ -51,7 +52,7 @@ export async function onRequestGet(c: any): Promise<Response> {
   const where = conditions.length ? `WHERE ${conditions.join(" AND ")}` : "";
 
   const users = await all<UserRow>(
-    c.env.DB,
+    requestDb(c),
     `SELECT u.id, u.email, u.first_name, u.last_name, u.organization_name, u.role, u.active, u.created_at
      FROM users u
      ${where}
@@ -63,7 +64,11 @@ export async function onRequestGet(c: any): Promise<Response> {
   const hasMore = users.length > limit;
   const rows = hasMore ? users.slice(0, limit) : users;
 
-  const totalRow = await first<{ total: number }>(c.env.DB, `SELECT COUNT(*) AS total FROM users u ${where}`, params);
+  const totalRow = await first<{ total: number }>(
+    requestDb(c),
+    `SELECT COUNT(*) AS total FROM users u ${where}`,
+    params,
+  );
   const total = Number(totalRow?.total ?? 0);
 
   return json({
@@ -72,7 +77,7 @@ export async function onRequestGet(c: any): Promise<Response> {
   });
 }
 
-export async function onRequest(c: any): Promise<Response> {
+export async function onRequest(c: AdminContext): Promise<Response> {
   if (c.req.raw.method !== "GET") {
     return json({ error: { code: "METHOD_NOT_ALLOWED", message: "Method not allowed" } }, 405);
   }

--- a/functions/api/v1/admin/users/[userId].ts
+++ b/functions/api/v1/admin/users/[userId].ts
@@ -15,6 +15,7 @@ import { first, run } from "../../../../_lib/db/queries";
 import { nowIso } from "../../../../_lib/utils/time";
 import { writeAuditLog } from "../../../../_lib/services/audit";
 import { adminUserUpdateSchema } from "../../../../../assets/shared/schemas/api";
+import { requestDb, type AdminContext } from "../../../../_lib/db/context";
 
 interface UserRow {
   id: string;
@@ -24,8 +25,8 @@ interface UserRow {
   pii_redacted_at: string | null;
 }
 
-export async function onRequestPatch(c: any): Promise<Response> {
-  const admin = await requireAdminFromRequest(c.env.DB, c.req.raw, c.env);
+export async function onRequestPatch(c: AdminContext): Promise<Response> {
+  const admin = await requireAdminFromRequest(requestDb(c), c.req.raw, c.env);
   const body = await parseJsonBody(c.req, adminUserUpdateSchema);
   const userId = c.req.param("userId");
 
@@ -40,7 +41,7 @@ export async function onRequestPatch(c: any): Promise<Response> {
   }
 
   const user = await first<UserRow>(
-    c.env.DB,
+    requestDb(c),
     "SELECT id, email, role, active, pii_redacted_at FROM users WHERE id = ?",
     [userId],
   );
@@ -52,7 +53,7 @@ export async function onRequestPatch(c: any): Promise<Response> {
   const newRole = body.role ?? user.role;
   const newActive = body.active ?? Boolean(user.active);
 
-  await run(c.env.DB, "UPDATE users SET role = ?, active = ?, updated_at = ? WHERE id = ?", [
+  await run(requestDb(c), "UPDATE users SET role = ?, active = ?, updated_at = ? WHERE id = ?", [
     newRole,
     newActive ? 1 : 0,
     nowIso(),
@@ -68,7 +69,7 @@ export async function onRequestPatch(c: any): Promise<Response> {
   }
 
   if (Object.keys(changes).length > 0) {
-    await writeAuditLog(c.env.DB, "admin", admin.id, "user_updated", "user", user.id, changes);
+    await writeAuditLog(requestDb(c), "admin", admin.id, "user_updated", "user", user.id, changes);
   }
 
   return json({
@@ -77,7 +78,7 @@ export async function onRequestPatch(c: any): Promise<Response> {
   });
 }
 
-export async function onRequest(c: any): Promise<Response> {
+export async function onRequest(c: AdminContext): Promise<Response> {
   if (c.req.raw.method !== "PATCH") {
     return json({ error: { code: "METHOD_NOT_ALLOWED", message: "Method not allowed" } }, 405);
   }

--- a/functions/api/v1/admin/users/[userId]/anonymize.ts
+++ b/functions/api/v1/admin/users/[userId]/anonymize.ts
@@ -21,6 +21,7 @@ import { first, run } from "../../../../../_lib/db/queries";
 import { nowIso } from "../../../../../_lib/utils/time";
 import { writeAuditLog } from "../../../../../_lib/services/audit";
 import { AppError } from "../../../../../_lib/errors";
+import { requestDb, type AdminContext } from "../../../../../_lib/db/context";
 
 interface UserRow {
   id: string;
@@ -30,8 +31,8 @@ interface UserRow {
   pii_redacted_at: string | null;
 }
 
-export async function onRequestPost(c: any): Promise<Response> {
-  const admin = await requireAdminFromRequest(c.env.DB, c.req.raw, c.env);
+export async function onRequestPost(c: AdminContext): Promise<Response> {
+  const admin = await requireAdminFromRequest(requestDb(c), c.req.raw, c.env);
   const userId = c.req.param("userId");
 
   if (userId === admin.id) {
@@ -39,7 +40,7 @@ export async function onRequestPost(c: any): Promise<Response> {
   }
 
   const user = await first<UserRow>(
-    c.env.DB,
+    requestDb(c),
     "SELECT id, email, role, active, pii_redacted_at FROM users WHERE id = ?",
     [userId],
   );
@@ -59,7 +60,7 @@ export async function onRequestPost(c: any): Promise<Response> {
   const redactedNormalized = redactedEmail;
 
   await run(
-    c.env.DB,
+    requestDb(c),
     `UPDATE users
      SET email             = ?,
          normalized_email  = ?,
@@ -82,12 +83,12 @@ export async function onRequestPost(c: any): Promise<Response> {
 
   // Revoke all non-expired sessions so the user is signed out immediately.
   await run(
-    c.env.DB,
+    requestDb(c),
     "UPDATE sessions SET revoked_at = ? WHERE user_id = ? AND revoked_at IS NULL AND expires_at > ?",
     [now, user.id, now],
   );
 
-  await writeAuditLog(c.env.DB, "admin", admin.id, "user_anonymized", "user", user.id, {
+  await writeAuditLog(requestDb(c), "admin", admin.id, "user_anonymized", "user", user.id, {
     previousEmail: user.email,
     previousRole: user.role,
   });
@@ -95,7 +96,7 @@ export async function onRequestPost(c: any): Promise<Response> {
   return json({ success: true, userId: user.id });
 }
 
-export async function onRequest(c: any): Promise<Response> {
+export async function onRequest(c: AdminContext): Promise<Response> {
   if (c.req.raw.method !== "POST") {
     return json({ error: { code: "METHOD_NOT_ALLOWED", message: "Method not allowed" } }, 405);
   }

--- a/functions/api/v1/admin/users/[userId]/gravatar.ts
+++ b/functions/api/v1/admin/users/[userId]/gravatar.ts
@@ -26,6 +26,7 @@ import { resolveAppBaseUrl } from "../../../../../_lib/config";
 import { invalidateAndRerender } from "../../../../../_lib/services/og-badge-prerender";
 import { writeAuditLog } from "../../../../../_lib/services/audit";
 import { AppError } from "../../../../../_lib/errors";
+import { requestDb, type AdminContext } from "../../../../../_lib/db/context";
 
 interface UserEmailRow {
   id: string;
@@ -35,11 +36,11 @@ interface UserEmailRow {
 
 // ── Handler ─────────────────────────────────────────────────────────────────
 
-export async function onRequestPost(c: any): Promise<Response> {
-  const admin = await requireAdminFromRequest(c.env.DB, c.req.raw, c.env);
+export async function onRequestPost(c: AdminContext): Promise<Response> {
+  const admin = await requireAdminFromRequest(requestDb(c), c.req.raw, c.env);
   const userId = c.req.param("userId");
 
-  const user = await first<UserEmailRow>(c.env.DB, "SELECT id, email, headshot_r2_key FROM users WHERE id = ?", [
+  const user = await first<UserEmailRow>(requestDb(c), "SELECT id, email, headshot_r2_key FROM users WHERE id = ?", [
     userId,
   ]);
   if (!user) throw new AppError(404, "NOT_FOUND", "User not found");
@@ -54,7 +55,7 @@ export async function onRequestPost(c: any): Promise<Response> {
     return json({ error: { code: "NO_GRAVATAR", message: "No Gravatar found for this email address" } }, 404);
   }
 
-  await writeAuditLog(c.env.DB, "admin", admin.id, "headshot_imported_gravatar", "user", user.id, {
+  await writeAuditLog(requestDb(c), "admin", admin.id, "headshot_imported_gravatar", "user", user.id, {
     r2Key,
     gravatarHash: emailHash,
   });
@@ -65,7 +66,7 @@ export async function onRequestPost(c: any): Promise<Response> {
   return json({ success: true, r2Key, source: "gravatar" });
 }
 
-export async function onRequest(c: any): Promise<Response> {
+export async function onRequest(c: AdminContext): Promise<Response> {
   if (c.req.raw.method !== "POST") {
     return json({ error: { code: "METHOD_NOT_ALLOWED", message: "Method not allowed" } }, 405);
   }

--- a/functions/api/v1/admin/users/[userId]/headshot.ts
+++ b/functions/api/v1/admin/users/[userId]/headshot.ts
@@ -17,6 +17,7 @@ import { resolveAppBaseUrl } from "../../../../../_lib/config";
 import { invalidateAndRerender } from "../../../../../_lib/services/og-badge-prerender";
 import { AppError } from "../../../../../_lib/errors";
 import { readUploadedImage, resizeHeadshot } from "../../../../../_lib/utils/headshot-upload";
+import { requestDb, type AdminContext } from "../../../../../_lib/db/context";
 const ALLOWED_MIME_TYPES = new Set(["image/jpeg", "image/png", "image/webp"]);
 const MAX_HEADSHOT_BYTES = 5 * 1024 * 1024; // 5 MB (raw input before admin crop UI; result will be a small JPEG)
 
@@ -27,10 +28,10 @@ interface HeadshotRow {
 
 // ── GET — serve the headshot image ──────────────────────────────────────────
 
-async function onGet(c: any): Promise<Response> {
-  await requireAdminFromRequest(c.env.DB, c.req.raw, c.env);
+async function onGet(c: AdminContext): Promise<Response> {
+  await requireAdminFromRequest(requestDb(c), c.req.raw, c.env);
 
-  const user = await first<HeadshotRow>(c.env.DB, "SELECT id, headshot_r2_key FROM users WHERE id = ?", [
+  const user = await first<HeadshotRow>(requestDb(c), "SELECT id, headshot_r2_key FROM users WHERE id = ?", [
     c.req.param("userId"),
   ]);
 
@@ -60,10 +61,10 @@ async function onGet(c: any): Promise<Response> {
 
 // ── PUT — upload / replace headshot ─────────────────────────────────────────
 
-async function onPut(c: any): Promise<Response> {
-  const admin = await requireAdminFromRequest(c.env.DB, c.req.raw, c.env);
+async function onPut(c: AdminContext): Promise<Response> {
+  const admin = await requireAdminFromRequest(requestDb(c), c.req.raw, c.env);
 
-  const user = await first<HeadshotRow>(c.env.DB, "SELECT id, headshot_r2_key FROM users WHERE id = ?", [
+  const user = await first<HeadshotRow>(requestDb(c), "SELECT id, headshot_r2_key FROM users WHERE id = ?", [
     c.req.param("userId"),
   ]);
   if (!user) throw new AppError(404, "NOT_FOUND", "User not found");
@@ -109,14 +110,13 @@ async function onPut(c: any): Promise<Response> {
   }
 
   const now = nowIso();
-  await run(c.env.DB, "UPDATE users SET headshot_r2_key = ?, headshot_updated_at = ?, updated_at = ? WHERE id = ?", [
-    r2Key,
-    now,
-    now,
-    user.id,
-  ]);
+  await run(
+    requestDb(c),
+    "UPDATE users SET headshot_r2_key = ?, headshot_updated_at = ?, updated_at = ? WHERE id = ?",
+    [r2Key, now, now, user.id],
+  );
 
-  await writeAuditLog(c.env.DB, "admin", admin.id, "headshot_uploaded", "user", user.id, {
+  await writeAuditLog(requestDb(c), "admin", admin.id, "headshot_uploaded", "user", user.id, {
     r2Key,
     uploadedBy: "admin",
   });
@@ -129,10 +129,10 @@ async function onPut(c: any): Promise<Response> {
 
 // ── DELETE — remove headshot ────────────────────────────────────────────────
 
-async function onDelete(c: any): Promise<Response> {
-  const admin = await requireAdminFromRequest(c.env.DB, c.req.raw, c.env);
+async function onDelete(c: AdminContext): Promise<Response> {
+  const admin = await requireAdminFromRequest(requestDb(c), c.req.raw, c.env);
 
-  const user = await first<HeadshotRow>(c.env.DB, "SELECT id, headshot_r2_key FROM users WHERE id = ?", [
+  const user = await first<HeadshotRow>(requestDb(c), "SELECT id, headshot_r2_key FROM users WHERE id = ?", [
     c.req.param("userId"),
   ]);
   if (!user) throw new AppError(404, "NOT_FOUND", "User not found");
@@ -144,12 +144,12 @@ async function onDelete(c: any): Promise<Response> {
 
   const now = nowIso();
   await run(
-    c.env.DB,
+    requestDb(c),
     "UPDATE users SET headshot_r2_key = NULL, headshot_updated_at = NULL, updated_at = ? WHERE id = ?",
     [now, user.id],
   );
 
-  await writeAuditLog(c.env.DB, "admin", admin.id, "headshot_removed", "user", user.id, {
+  await writeAuditLog(requestDb(c), "admin", admin.id, "headshot_removed", "user", user.id, {
     previousKey: user.headshot_r2_key,
   });
 
@@ -158,7 +158,7 @@ async function onDelete(c: any): Promise<Response> {
 
 // ── Router ──────────────────────────────────────────────────────────────────
 
-export async function onRequest(c: any): Promise<Response> {
+export async function onRequest(c: AdminContext): Promise<Response> {
   switch (c.req.raw.method) {
     case "GET":
       return onGet(c);
@@ -174,7 +174,7 @@ export async function onRequest(c: any): Promise<Response> {
 export class AdminUsersUserIdHeadshotGet extends OpenAPIRoute {
   schema = {};
 
-  async handle(c: any) {
+  async handle(c: AdminContext) {
     return onGet(c);
   }
 }
@@ -182,7 +182,7 @@ export class AdminUsersUserIdHeadshotGet extends OpenAPIRoute {
 export class AdminUsersUserIdHeadshotPut extends OpenAPIRoute {
   schema = {};
 
-  async handle(c: any) {
+  async handle(c: AdminContext) {
     return onPut(c);
   }
 }
@@ -190,7 +190,7 @@ export class AdminUsersUserIdHeadshotPut extends OpenAPIRoute {
 export class AdminUsersUserIdHeadshotDelete extends OpenAPIRoute {
   schema = {};
 
-  async handle(c: any) {
+  async handle(c: AdminContext) {
     return onDelete(c);
   }
 }

--- a/functions/api/v1/admin/users/[userId]/index.ts
+++ b/functions/api/v1/admin/users/[userId]/index.ts
@@ -12,6 +12,7 @@ import { nowIso } from "../../../../../_lib/utils/time";
 import { writeAuditLog } from "../../../../../_lib/services/audit";
 import { AppError } from "../../../../../_lib/errors";
 import { adminUserUpdateSchema } from "../../../../../../assets/shared/schemas/api";
+import { requestDb, type AdminContext } from "../../../../../_lib/db/context";
 
 interface UserRow {
   id: string;
@@ -41,12 +42,12 @@ interface UserDetailRow {
 
 // ── GET ─────────────────────────────────────────────────────────────────────
 
-export async function onRequestGet(c: any): Promise<Response> {
-  await requireAdminFromRequest(c.env.DB, c.req.raw, c.env);
+export async function onRequestGet(c: AdminContext): Promise<Response> {
+  await requireAdminFromRequest(requestDb(c), c.req.raw, c.env);
   const userId = c.req.param("userId");
 
   const user = await first<UserDetailRow>(
-    c.env.DB,
+    requestDb(c),
     `SELECT id, email, first_name, last_name, preferred_name,
             organization_name, job_title, biography, role, active,
             headshot_r2_key, headshot_updated_at,
@@ -77,8 +78,8 @@ export async function onRequestGet(c: any): Promise<Response> {
 
 // ── PATCH ───────────────────────────────────────────────────────────────────
 
-export async function onRequestPatch(c: any): Promise<Response> {
-  const admin = await requireAdminFromRequest(c.env.DB, c.req.raw, c.env);
+export async function onRequestPatch(c: AdminContext): Promise<Response> {
+  const admin = await requireAdminFromRequest(requestDb(c), c.req.raw, c.env);
   const body = await parseJsonBody(c.req, adminUserUpdateSchema);
   const userId = c.req.param("userId");
 
@@ -93,7 +94,7 @@ export async function onRequestPatch(c: any): Promise<Response> {
   }
 
   const user = await first<UserRow>(
-    c.env.DB,
+    requestDb(c),
     "SELECT id, email, role, active, pii_redacted_at FROM users WHERE id = ?",
     [userId],
   );
@@ -111,7 +112,7 @@ export async function onRequestPatch(c: any): Promise<Response> {
     const normalized = normalizeEmail(body.email);
     if (normalized !== normalizeEmail(user.email)) {
       const existing = await first<{ id: string }>(
-        c.env.DB,
+        requestDb(c),
         "SELECT id FROM users WHERE normalized_email = ? AND id != ?",
         [normalized, user.id],
       );
@@ -146,7 +147,7 @@ export async function onRequestPatch(c: any): Promise<Response> {
   let currentDetail: UserDetailRow | null = null;
   if (hasPiiUpdates) {
     currentDetail = await first<UserDetailRow>(
-      c.env.DB,
+      requestDb(c),
       `SELECT id, email, first_name, last_name, preferred_name, organization_name, job_title, biography,
               role, active, headshot_r2_key, headshot_updated_at, created_at, updated_at, pii_redacted_at
        FROM users WHERE id = ?`,
@@ -157,11 +158,11 @@ export async function onRequestPatch(c: any): Promise<Response> {
   if (hasPiiUpdates) {
     const setClauses = safeKeys.map((col) => `${col} = ?`).join(", ");
     const values = [...safeKeys.map((col) => piiUpdates[col]), nowIso(), user.id];
-    await run(c.env.DB, `UPDATE users SET ${setClauses}, updated_at = ? WHERE id = ?`, values);
+    await run(requestDb(c), `UPDATE users SET ${setClauses}, updated_at = ? WHERE id = ?`, values);
   }
 
   await run(
-    c.env.DB,
+    requestDb(c),
     "UPDATE users SET email = ?, normalized_email = ?, role = ?, active = ?, updated_at = ? WHERE id = ?",
     [newEmail, normalizeEmail(newEmail), newRole, newActive ? 1 : 0, nowIso(), user.id],
   );
@@ -187,7 +188,7 @@ export async function onRequestPatch(c: any): Promise<Response> {
   }
 
   if (Object.keys(changes).length > 0) {
-    await writeAuditLog(c.env.DB, "admin", admin.id, "user_updated", "user", user.id, changes);
+    await writeAuditLog(requestDb(c), "admin", admin.id, "user_updated", "user", user.id, changes);
   }
 
   return json({
@@ -196,7 +197,7 @@ export async function onRequestPatch(c: any): Promise<Response> {
   });
 }
 
-export async function onRequest(c: any): Promise<Response> {
+export async function onRequest(c: AdminContext): Promise<Response> {
   if (c.req.raw.method === "GET") return onRequestGet(c);
   if (c.req.raw.method === "PATCH") return onRequestPatch(c);
   return json({ error: { code: "METHOD_NOT_ALLOWED", message: "Method not allowed" } }, 405);

--- a/functions/api/v1/admin/users/[userId]/router.ts
+++ b/functions/api/v1/admin/users/[userId]/router.ts
@@ -7,8 +7,9 @@ import { AdminUsersUserIdHeadshotGet } from "./headshot";
 import { AdminUsersUserIdHeadshotDelete } from "./headshot";
 import { onRequestGet as AdminUsersUserIdGet_l } from "./index";
 import { onRequestPatch as AdminUsersUserIdPatch_l } from "./index";
+import type { RequestDbContext } from "../../../../../_lib/db/context";
 
-const app = new Hono();
+const app = new Hono<RequestDbContext>();
 export const openapi = fromHono(app);
 
 app.post("/anonymize", AdminUsersUserIdAnonymizePost_l);

--- a/functions/api/v1/admin/users/router.ts
+++ b/functions/api/v1/admin/users/router.ts
@@ -2,8 +2,9 @@ import { Hono } from "hono";
 import { fromHono } from "chanfana";
 import { onRequestPatch as AdminUsersUserIdPatch_l } from "./[userId]";
 import userId_Router from "./[userId]/router";
+import type { RequestDbContext } from "../../../../_lib/db/context";
 
-const app = new Hono();
+const app = new Hono<RequestDbContext>();
 export const openapi = fromHono(app);
 
 app.patch("/:userId", AdminUsersUserIdPatch_l);

--- a/tests/admin-email-templates-endpoints.test.ts
+++ b/tests/admin-email-templates-endpoints.test.ts
@@ -6,7 +6,7 @@ import { createAdminSession } from "./helpers/auth";
 import { queryAll, seedEventAndAdmin } from "./helpers/context";
 import { seedWorkflowEmailTemplates } from "./helpers/event-workflow";
 
-const ADMIN_TOKEN = "email-templates-admin-token";
+let ADMIN_TOKEN = "email-templates-admin-token";
 
 function adminRequest(path: string, init: RequestInit = {}): Request {
   const headers = new Headers(init.headers);
@@ -34,7 +34,7 @@ async function setupAdminTemplates(): Promise<{ adminId: string }> {
   const adminRow = (
     await queryAll<{ id: string }>(env.DB, "SELECT id FROM users WHERE email = 'admin@pkic.org' LIMIT 1")
   )[0];
-  await createAdminSession(env.DB, adminRow.id, ADMIN_TOKEN);
+  ADMIN_TOKEN = await createAdminSession(env.DB, adminRow.id, ADMIN_TOKEN);
   await seedWorkflowEmailTemplates(env.DB, adminRow.id);
   return { adminId: adminRow.id };
 }

--- a/tests/admin-event-management.test.ts
+++ b/tests/admin-event-management.test.ts
@@ -11,7 +11,7 @@ import {
   updateRegistrationById,
 } from "../functions/_lib/services/registrations";
 
-const ADMIN_TOKEN = "event-admin-token";
+let ADMIN_TOKEN = "event-admin-token";
 
 function adminRequest(path: string, init: RequestInit = {}): Request {
   const headers = new Headers(init.headers);
@@ -39,7 +39,7 @@ async function setupAdmin(): Promise<{ baseEventId: string }> {
   const adminRow = (
     await queryAll<{ id: string }>(env.DB, "SELECT id FROM users WHERE email = 'admin@pkic.org' LIMIT 1")
   )[0];
-  await createAdminSession(env.DB, adminRow.id, ADMIN_TOKEN);
+  ADMIN_TOKEN = await createAdminSession(env.DB, adminRow.id, ADMIN_TOKEN);
   return { baseEventId: eventId };
 }
 

--- a/tests/admin-forms-endpoints.test.ts
+++ b/tests/admin-forms-endpoints.test.ts
@@ -6,7 +6,7 @@ import { createAdminSession } from "./helpers/auth";
 import { queryAll, seedEventAndAdmin } from "./helpers/context";
 import { nowIso } from "../functions/_lib/utils/time";
 
-const ADMIN_TOKEN = "forms-admin-token";
+let ADMIN_TOKEN = "forms-admin-token";
 
 type FormFieldSeed = {
   key: string;
@@ -44,7 +44,7 @@ async function setupAdmin(): Promise<{ eventId: string }> {
   const adminRow = (
     await queryAll<{ id: string }>(env.DB, "SELECT id FROM users WHERE email = 'admin@pkic.org' LIMIT 1")
   )[0];
-  await createAdminSession(env.DB, adminRow.id, ADMIN_TOKEN);
+  ADMIN_TOKEN = await createAdminSession(env.DB, adminRow.id, ADMIN_TOKEN);
   return { eventId };
 }
 

--- a/tests/admin-invite-chunked-bulk.test.ts
+++ b/tests/admin-invite-chunked-bulk.test.ts
@@ -29,7 +29,7 @@ import type { Env as AppEnv } from "../functions/_lib/types";
 const appEnv = env as unknown as AppEnv;
 
 const EVENT_SLUG = "pqc-2026";
-const RAW_TOKEN = "chunked-bulk-test-token";
+let RAW_TOKEN = "chunked-bulk-test-token";
 
 async function seedRequiredTemplates(adminId: string): Promise<void> {
   for (const [key, content, subject] of [
@@ -65,7 +65,7 @@ describe("attendee invite — chunked bulk send", () => {
     await seedEventAndAdmin(appEnv.DB);
     const row = (await queryAll<{ id: string }>(appEnv.DB, "SELECT id FROM users WHERE role = 'admin' LIMIT 1"))[0];
     adminId = row.id;
-    await createAdminSession(appEnv.DB, adminId, RAW_TOKEN);
+    RAW_TOKEN = await createAdminSession(appEnv.DB, adminId, RAW_TOKEN);
     await seedRequiredTemplates(adminId);
   });
 

--- a/tests/admin-proposals-endpoints.test.ts
+++ b/tests/admin-proposals-endpoints.test.ts
@@ -157,13 +157,13 @@ describe("admin proposal endpoints", () => {
     const { eventId } = await seedEventAndAdmin(env.DB);
     const { adminId } = await seedProposalWithReviews(env.DB, eventId);
 
-    await createAdminSession(env.DB, adminId, "token-admin-list");
+    const adminToken = await createAdminSession(env.DB, adminId, "token-admin-list");
 
     const response = await getEventProposals(
       createContext(
         env,
         new Request("https://app.test/api/v1/admin/events/pqc-2026/proposals", {
-          headers: { authorization: "Bearer token-admin-list" },
+          headers: { authorization: `Bearer ${adminToken}` },
         }),
         { eventSlug: "pqc-2026" },
       ),
@@ -188,13 +188,13 @@ describe("admin proposal endpoints", () => {
     const { eventId } = await seedEventAndAdmin(env.DB);
     const { proposalId, adminId } = await seedProposalWithReviews(env.DB, eventId);
 
-    await createAdminSession(env.DB, adminId, "token-admin-detail");
+    const adminToken = await createAdminSession(env.DB, adminId, "token-admin-detail");
 
     const response = await getProposalDetail(
       createContext(
         env,
         new Request(`https://app.test/api/v1/admin/proposals/${proposalId}`, {
-          headers: { authorization: "Bearer token-admin-detail" },
+          headers: { authorization: `Bearer ${adminToken}` },
         }),
         { proposalId },
       ),
@@ -220,13 +220,13 @@ describe("admin proposal endpoints", () => {
     const { eventId } = await seedEventAndAdmin(env.DB);
     const { proposalId, adminId } = await seedProposalWithReviews(env.DB, eventId);
 
-    await createAdminSession(env.DB, adminId, "token-admin-reviews");
+    const adminToken = await createAdminSession(env.DB, adminId, "token-admin-reviews");
 
     const response = await getProposalReviews(
       createContext(
         env,
         new Request(`https://app.test/api/v1/admin/proposals/${proposalId}/reviews`, {
-          headers: { authorization: "Bearer token-admin-reviews" },
+          headers: { authorization: `Bearer ${adminToken}` },
         }),
         { proposalId },
       ),
@@ -246,14 +246,14 @@ describe("admin proposal endpoints", () => {
     const { eventId } = await seedEventAndAdmin(env.DB);
     const { proposalId, adminId } = await seedProposalWithReviews(env.DB, eventId);
 
-    await createAdminSession(env.DB, adminId, "token-admin-manage");
+    const adminToken = await createAdminSession(env.DB, adminId, "token-admin-manage");
 
     const response = await openProposalManage(
       createContext(
         env,
         new Request(`https://app.test/api/v1/admin/proposals/${proposalId}/open-manage`, {
           method: "POST",
-          headers: { authorization: "Bearer token-admin-manage" },
+          headers: { authorization: `Bearer ${adminToken}` },
         }),
         { proposalId },
       ),

--- a/tests/admin-user-headshot.test.ts
+++ b/tests/admin-user-headshot.test.ts
@@ -6,7 +6,7 @@ import { createAdminSession } from "./helpers/auth";
 import { onRequest as adminUserHeadshotRequest } from "../functions/api/v1/admin/users/[userId]/headshot";
 import app from "../functions/router";
 
-const ADMIN_TOKEN = "admin-session-token";
+let ADMIN_TOKEN = "admin-session-token";
 
 interface StoredObject {
   body: ArrayBuffer;
@@ -62,7 +62,7 @@ async function setup(): Promise<{ adminId: string; targetUserId: string }> {
   const adminId = (
     await queryAll<{ id: string }>(env.DB, "SELECT id FROM users WHERE email = 'admin@pkic.org' LIMIT 1")
   )[0].id;
-  await createAdminSession(env.DB, adminId, ADMIN_TOKEN);
+  ADMIN_TOKEN = await createAdminSession(env.DB, adminId, ADMIN_TOKEN);
 
   const targetUserId = crypto.randomUUID();
   await env.DB.prepare(

--- a/tests/admin-user-management.test.ts
+++ b/tests/admin-user-management.test.ts
@@ -7,14 +7,14 @@ import { resetDb } from "./helpers/reset-db";
 import { onRequestPatch as patchUser } from "../functions/api/v1/admin/users/[userId]/index";
 import { onRequestPost as anonymizeUser } from "../functions/api/v1/admin/users/[userId]/anonymize";
 
-const ADMIN_TOKEN = "admin-session-token";
+let adminToken: string;
 
 async function setup() {
   await seedEventAndAdmin(env.DB);
   const adminId = (
     await queryAll<{ id: string }>(env.DB, "SELECT id FROM users WHERE email = 'admin@pkic.org' LIMIT 1")
   )[0].id;
-  await createAdminSession(env.DB, adminId, ADMIN_TOKEN);
+  adminToken = await createAdminSession(env.DB, adminId, "admin-session-token");
   return { adminId, env };
 }
 
@@ -23,7 +23,7 @@ function adminRequest(path: string, method: string, body?: unknown): Request {
     method,
     headers: {
       "content-type": "application/json",
-      authorization: `Bearer ${ADMIN_TOKEN}`,
+      authorization: `Bearer ${adminToken}`,
     },
     body: body !== undefined ? JSON.stringify(body) : undefined,
   });
@@ -34,9 +34,11 @@ async function seedUser(_db: DatabaseLike, email: string): Promise<string> {
   await env.DB.prepare(
     `
     INSERT INTO users (id, email, normalized_email, first_name, last_name, role, active, created_at, updated_at)
-    VALUES ('${userId}', '${email}', '${email}', 'Test', 'User', 'user', 1, datetime('now'), datetime('now'));
+    VALUES (?, ?, ?, 'Test', 'User', 'user', 1, datetime('now'), datetime('now'));
   `,
-  ).run();
+  )
+    .bind(userId, email, email)
+    .run();
   return userId;
 }
 

--- a/tests/admin-vip-admit.test.ts
+++ b/tests/admin-vip-admit.test.ts
@@ -50,7 +50,7 @@ describe("admin VIP admit", () => {
     const adminId = (
       await queryAll<{ id: string }>(env.DB, "SELECT id FROM users WHERE email = 'admin@pkic.org' LIMIT 1")
     )[0].id;
-    await createAdminSession(env.DB, adminId, "admin-token");
+    const adminToken = await createAdminSession(env.DB, adminId, "admin-token");
 
     const holderSeed = await seedInvite(env.DB, eventId, "holder@example.test");
     const vipSeed = await seedInvite(env.DB, eventId, "vip@example.test");
@@ -91,7 +91,7 @@ describe("admin VIP admit", () => {
         new Request("https://app.test/api/v1/admin/events/pqc-2026/registrations/x/admit", {
           method: "POST",
           headers: {
-            authorization: "Bearer admin-token",
+            authorization: `Bearer ${adminToken}`,
             "content-type": "application/json",
           },
           body: JSON.stringify({

--- a/tests/api-security.test.ts
+++ b/tests/api-security.test.ts
@@ -20,6 +20,7 @@ import { resetDb } from "./helpers/reset-db";
 import { SELF, env } from "cloudflare:test";
 import { createContext, seedEventAndAdmin, queryAll } from "./helpers/context";
 import { createAdminSession } from "./helpers/auth";
+import { signAdminSessionToken } from "../functions/_lib/auth/admin";
 import { sha256Hex } from "../functions/_lib/utils/crypto";
 import { nowIso } from "../functions/_lib/utils/time";
 import type { DatabaseLike, Env as AppEnv } from "../functions/_lib/types";
@@ -81,17 +82,24 @@ async function insertSession(
   userId: string,
   rawToken: string,
   opts: { expiresAt?: string; revokedAt?: string } = {},
-): Promise<void> {
+): Promise<string> {
+  const sessionId = crypto.randomUUID();
   const tokenHash = await sha256Hex(rawToken);
   const expiresAt = opts.expiresAt ?? new Date(Date.now() + 8 * 3600 * 1000).toISOString();
   const revokedAt = opts.revokedAt ?? null;
   await env.DB.prepare(
     `
     INSERT INTO sessions (id, user_id, token_hash, expires_at, revoked_at, created_at)
-    VALUES ('${crypto.randomUUID()}', '${userId}', '${tokenHash}',
+    VALUES ('${sessionId}', '${userId}', '${tokenHash}',
             '${expiresAt}', ${revokedAt ? `'${revokedAt}'` : "NULL"}, '${nowIso()}');
   `,
   ).run();
+
+  return signAdminSessionToken(env.INTERNAL_SIGNING_SECRET ?? "test-signing-secret", {
+    admin: { id: userId, email: "admin@example.test", role: "admin" },
+    sessionId,
+    expiresAt,
+  });
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -383,15 +391,15 @@ describe("session-token validation", () => {
 
   it("rejects an expired session → AUTH_EXPIRED", async () => {
     const expiredAt = new Date(Date.now() - 1000).toISOString(); // 1 s in the past
-    await insertSession(env.DB, adminId, "expired-token", { expiresAt: expiredAt });
-    const response = await callUsers("expired-token");
+    const token = await insertSession(env.DB, adminId, "expired-token", { expiresAt: expiredAt });
+    const response = await callUsers(token);
     expect(response.status).toBe(401);
     expect(((await response.json()) as { error?: { code?: string } }).error?.code).toBe("AUTH_EXPIRED");
   });
 
   it("rejects a revoked session → AUTH_REVOKED", async () => {
-    await insertSession(env.DB, adminId, "revoked-token", { revokedAt: nowIso() });
-    const response = await callUsers("revoked-token");
+    const token = await insertSession(env.DB, adminId, "revoked-token", { revokedAt: nowIso() });
+    const response = await callUsers(token);
     expect(response.status).toBe(401);
     expect(((await response.json()) as { error?: { code?: string } }).error?.code).toBe("AUTH_REVOKED");
   });
@@ -405,9 +413,9 @@ describe("session-token validation", () => {
               'user', 1, datetime('now'), datetime('now'));
     `,
     ).run();
-    await insertSession(env.DB, regularUserId, "user-token");
+    const token = await insertSession(env.DB, regularUserId, "user-token");
     // A regular user's session must not grant admin access
-    const response = await callUsers("user-token");
+    const response = await callUsers(token);
     expect(response.status).toBe(401);
     expect(((await response.json()) as { error?: { code?: string } }).error?.code).toBe("AUTH_INVALID");
   });
@@ -421,8 +429,8 @@ describe("session-token validation", () => {
               'admin', 0, datetime('now'), datetime('now'));
     `,
     ).run();
-    await insertSession(env.DB, inactiveAdminId, "inactive-admin-token");
-    const response = await callUsers("inactive-admin-token");
+    const token = await insertSession(env.DB, inactiveAdminId, "inactive-admin-token");
+    const response = await callUsers(token);
     expect(response.status).toBe(401);
     expect(((await response.json()) as { error?: { code?: string } }).error?.code).toBe("AUTH_INVALID");
   });
@@ -433,8 +441,8 @@ describe("session-token validation", () => {
   });
 
   it("accepts a valid active admin session token", async () => {
-    await createAdminSession(env.DB, adminId, "valid-admin-token");
-    const response = await callUsers("valid-admin-token");
+    const token = await createAdminSession(env.DB, adminId, "valid-admin-token");
+    const response = await callUsers(token);
     expect(response.status).toBe(200);
   });
 });

--- a/tests/d1-read-replication.test.ts
+++ b/tests/d1-read-replication.test.ts
@@ -1,9 +1,32 @@
 import { describe, expect, it } from "vitest";
 import adminRouter from "../functions/api/v1/admin/router";
-import { cacheAdminForRequest, requireAdminFromRequest } from "../functions/_lib/auth/admin";
+import {
+  cacheAdminForRequest,
+  requireAdminFromRequest,
+  signAdminSessionToken,
+  verifyAdminSessionToken,
+} from "../functions/_lib/auth/admin";
 import type { AuthAdmin, DatabaseLike, StatementLike } from "../functions/_lib/types";
 
-function emptyStatement(query: string, queries: string[]): StatementLike {
+const signingSecret = "test-admin-signing-secret";
+const adminTokenExpiresAt = "2999-01-01T00:00:00.000Z";
+
+async function createAdminToken(state?: string | null): Promise<string> {
+  return signAdminSessionToken(signingSecret, {
+    admin: { id: "admin-user", email: "admin@example.test", role: "admin" },
+    sessionId: "admin-session",
+    expiresAt: adminTokenExpiresAt,
+    state,
+  });
+}
+
+interface StatementOptions {
+  onQuery?: () => void;
+  waitForQuery?: () => Promise<void>;
+  bookmark?: string | null;
+}
+
+function emptyStatement(query: string, queries: string[], options: StatementOptions = {}): StatementLike {
   queries.push(query);
   return {
     bind() {
@@ -13,37 +36,45 @@ function emptyStatement(query: string, queries: string[]): StatementLike {
       return { success: true, meta: { changes: 0 } };
     },
     async all<T>() {
+      options.onQuery?.();
+      await options.waitForQuery?.();
       return { results: [] as T[] };
     },
     async first<T>() {
       if (query.includes("FROM sessions")) {
         return {
+          id: "admin-session",
           user_id: "admin-user",
-          expires_at: "2999-01-01T00:00:00.000Z",
+          expires_at: adminTokenExpiresAt,
           revoked_at: null,
           email: "admin@example.test",
           role: "admin",
         } as T;
       }
+      options.onQuery?.();
+      await options.waitForQuery?.();
       return null;
     },
   };
 }
 
-function createDbWithSessionRecorder() {
+function createDbWithSessionRecorder(options: StatementOptions = {}) {
   const primaryQueries: string[] = [];
   const sessionQueries: string[] = [];
   const withSessionCalls: string[] = [];
 
-  const sessionDb: DatabaseLike = {
+  const sessionDb: DatabaseLike & { getBookmark(): string | null } = {
     prepare(query) {
       if (query.includes("FROM sessions")) {
         throw new Error("admin auth should stay on the primary DB");
       }
-      return emptyStatement(query, sessionQueries);
+      return emptyStatement(query, sessionQueries, options);
     },
     async batch() {
       return [];
+    },
+    getBookmark() {
+      return options.bookmark ?? null;
     },
   };
 
@@ -66,12 +97,13 @@ function createDbWithSessionRecorder() {
 describe("D1 read replication", () => {
   it("uses a first-unconstrained D1 session for admin GET reads after primary auth", async () => {
     const { primaryDb, primaryQueries, sessionQueries, withSessionCalls } = createDbWithSessionRecorder();
+    const adminToken = await createAdminToken();
 
     const response = await adminRouter.fetch(
       new Request("https://app.test/stats", {
-        headers: { authorization: "Bearer admin-token" },
+        headers: { authorization: `Bearer ${adminToken}` },
       }),
-      { DB: primaryDb } as any,
+      { DB: primaryDb, INTERNAL_SIGNING_SECRET: signingSecret } as any,
       { passThroughOnException: () => {}, waitUntil: () => {} } as any,
     );
 
@@ -80,6 +112,59 @@ describe("D1 read replication", () => {
     expect(primaryQueries.some((query) => query.includes("FROM sessions"))).toBe(true);
     expect(sessionQueries.some((query) => query.includes("FROM sessions"))).toBe(false);
     expect(sessionQueries.some((query) => query.includes("FROM registrations"))).toBe(true);
+  });
+
+  it("does not mutate the shared env DB binding while admin GET reads are in flight", async () => {
+    let releaseSessionQueries!: () => void;
+    let markSessionQueryStarted!: () => void;
+    const sessionQueryStarted = new Promise<void>((resolve) => {
+      markSessionQueryStarted = resolve;
+    });
+    const waitForQuery = new Promise<void>((resolve) => {
+      releaseSessionQueries = resolve;
+    });
+    const { primaryDb } = createDbWithSessionRecorder({
+      onQuery: markSessionQueryStarted,
+      waitForQuery: () => waitForQuery,
+    });
+    const env = { DB: primaryDb, INTERNAL_SIGNING_SECRET: signingSecret } as any;
+    const adminToken = await createAdminToken();
+
+    const responsePromise = adminRouter.fetch(
+      new Request("https://app.test/stats", {
+        headers: { authorization: `Bearer ${adminToken}` },
+      }),
+      env,
+      { passThroughOnException: () => {}, waitUntil: () => {} } as any,
+    );
+
+    await sessionQueryStarted;
+    expect(env.DB).toBe(primaryDb);
+
+    releaseSessionQueries();
+    const response = await responsePromise;
+    expect(response.status).toBe(200);
+  });
+
+  it("uses existing D1 bookmarks for admin GET sessions and emits the next bookmark", async () => {
+    const { primaryDb, withSessionCalls } = createDbWithSessionRecorder({ bookmark: "next/bookmark" });
+    const adminToken = await createAdminToken("prior/bookmark");
+
+    const response = await adminRouter.fetch(
+      new Request("https://app.test/stats", {
+        headers: { authorization: `Bearer ${adminToken}` },
+      }),
+      { DB: primaryDb, INTERNAL_SIGNING_SECRET: signingSecret } as any,
+      { passThroughOnException: () => {}, waitUntil: () => {} } as any,
+    );
+
+    expect(response.status).toBe(200);
+    expect(withSessionCalls).toEqual(["prior/bookmark"]);
+    const rotatedToken = response.headers.get("x-admin-token");
+    expect(rotatedToken).toBeTruthy();
+    const verified = await verifyAdminSessionToken(signingSecret, rotatedToken!);
+    expect(verified.ok && verified.claims.state).toBe("next/bookmark");
+    expect(response.headers.has("set-cookie")).toBe(false);
   });
 
   it("serves cached admin identities for the same request without another DB lookup", async () => {

--- a/tests/d1-read-replication.test.ts
+++ b/tests/d1-read-replication.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import adminRouter from "../functions/api/v1/admin/router";
+import { cacheAdminForRequest, requireAdminFromRequest } from "../functions/_lib/auth/admin";
+import type { AuthAdmin, DatabaseLike, StatementLike } from "../functions/_lib/types";
+
+function emptyStatement(query: string, queries: string[]): StatementLike {
+  queries.push(query);
+  return {
+    bind() {
+      return this;
+    },
+    async run() {
+      return { success: true, meta: { changes: 0 } };
+    },
+    async all<T>() {
+      return { results: [] as T[] };
+    },
+    async first<T>() {
+      if (query.includes("FROM sessions")) {
+        return {
+          user_id: "admin-user",
+          expires_at: "2999-01-01T00:00:00.000Z",
+          revoked_at: null,
+          email: "admin@example.test",
+          role: "admin",
+        } as T;
+      }
+      return null;
+    },
+  };
+}
+
+function createDbWithSessionRecorder() {
+  const primaryQueries: string[] = [];
+  const sessionQueries: string[] = [];
+  const withSessionCalls: string[] = [];
+
+  const sessionDb: DatabaseLike = {
+    prepare(query) {
+      if (query.includes("FROM sessions")) {
+        throw new Error("admin auth should stay on the primary DB");
+      }
+      return emptyStatement(query, sessionQueries);
+    },
+    async batch() {
+      return [];
+    },
+  };
+
+  const primaryDb: DatabaseLike = {
+    prepare(query) {
+      return emptyStatement(query, primaryQueries);
+    },
+    async batch() {
+      return [];
+    },
+    withSession(constraintOrBookmark) {
+      withSessionCalls.push(String(constraintOrBookmark));
+      return sessionDb;
+    },
+  };
+
+  return { primaryDb, primaryQueries, sessionQueries, withSessionCalls };
+}
+
+describe("D1 read replication", () => {
+  it("uses a first-unconstrained D1 session for admin GET reads after primary auth", async () => {
+    const { primaryDb, primaryQueries, sessionQueries, withSessionCalls } = createDbWithSessionRecorder();
+
+    const response = await adminRouter.fetch(
+      new Request("https://app.test/stats", {
+        headers: { authorization: "Bearer admin-token" },
+      }),
+      { DB: primaryDb } as any,
+      { passThroughOnException: () => {}, waitUntil: () => {} } as any,
+    );
+
+    expect(response.status).toBe(200);
+    expect(withSessionCalls).toEqual(["first-unconstrained"]);
+    expect(primaryQueries.some((query) => query.includes("FROM sessions"))).toBe(true);
+    expect(sessionQueries.some((query) => query.includes("FROM sessions"))).toBe(false);
+    expect(sessionQueries.some((query) => query.includes("FROM registrations"))).toBe(true);
+  });
+
+  it("serves cached admin identities for the same request without another DB lookup", async () => {
+    const request = new Request("https://app.test/admin", {
+      headers: { authorization: "Bearer stale-token" },
+    });
+    const admin: AuthAdmin = { id: "admin-user", email: "admin@example.test", role: "admin" };
+    const throwingDb: DatabaseLike = {
+      prepare() {
+        throw new Error("unexpected DB lookup");
+      },
+      async batch() {
+        return [];
+      },
+    };
+
+    cacheAdminForRequest(request, admin);
+
+    await expect(requireAdminFromRequest(throwingDb, request)).resolves.toEqual(admin);
+  });
+});

--- a/tests/full-workflow.test.ts
+++ b/tests/full-workflow.test.ts
@@ -162,7 +162,7 @@ describe("full workflow", () => {
       VALUES ('${reviewerUserId}', 'reviewer2@pkic.org', 'reviewer2@pkic.org', 'admin', 1, datetime('now'), datetime('now'));
     `,
       ).run();
-      await createAdminSession(env.DB, reviewerUserId, "reviewer-2-token");
+      const reviewerToken = await createAdminSession(env.DB, reviewerUserId, "reviewer-2-token");
 
       const speakerInviteResponse = await inviteSpeakersBulk(
         createContext(
@@ -242,7 +242,7 @@ describe("full workflow", () => {
             method: "POST",
             headers: {
               "content-type": "application/json",
-              authorization: "Bearer reviewer-2-token",
+              authorization: `Bearer ${reviewerToken}`,
             },
             body: JSON.stringify({
               recommendation: "accept",

--- a/tests/helpers/auth.ts
+++ b/tests/helpers/auth.ts
@@ -1,15 +1,32 @@
 import { sha256Hex } from "../../functions/_lib/utils/crypto";
 import { nowIso, addHours } from "../../functions/_lib/utils/time";
+import { signAdminSessionToken } from "../../functions/_lib/auth/admin";
 import type { DatabaseLike } from "../../functions/_lib/types";
+import { env } from "cloudflare:test";
 
-export async function createAdminSession(db: DatabaseLike, adminUserId: string, rawToken: string): Promise<void> {
+export async function createAdminSession(
+  db: DatabaseLike,
+  adminUserId: string,
+  rawToken: string,
+  signingSecret: string = env.INTERNAL_SIGNING_SECRET ?? "test-signing-secret",
+): Promise<string> {
+  const sessionId = crypto.randomUUID();
   const tokenHash = await sha256Hex(rawToken);
+  const now = nowIso();
+  const expiresAt = addHours(now, 8);
   await db
     .prepare(
       `
     INSERT INTO sessions (id, user_id, token_hash, expires_at, revoked_at, created_at)
-    VALUES ('${crypto.randomUUID()}', '${adminUserId}', '${tokenHash}', '${addHours(nowIso(), 8)}', NULL, '${nowIso()}');
+    VALUES (?, ?, ?, ?, NULL, ?);
   `,
     )
+    .bind(sessionId, adminUserId, tokenHash, expiresAt, now)
     .run();
+
+  return signAdminSessionToken(signingSecret, {
+    admin: { id: adminUserId, email: "admin@example.test", role: "admin" },
+    sessionId,
+    expiresAt,
+  });
 }

--- a/tests/helpers/context.ts
+++ b/tests/helpers/context.ts
@@ -1,4 +1,5 @@
 import type { DatabaseLike, Env, PagesContext } from "../../functions/_lib/types";
+import type { AdminContext } from "../../functions/_lib/db/context";
 import type { RateLimitBinding } from "../../functions/_lib/rate-limit";
 
 /**
@@ -20,11 +21,17 @@ export function createContext<P extends Record<string, string>>(
   env: Env,
   request: Request,
   params: P,
-): PagesContext<P> {
+): PagesContext<P> & AdminContext<P> {
   const data: Record<string, unknown> = {};
   const waitUntil = (promise: Promise<unknown>) => {
     void promise.catch(() => undefined);
   };
+
+  function param(name: string): string;
+  function param(): P;
+  function param(name?: string): string | P {
+    return name ? params[name] : params;
+  }
 
   return {
     env,
@@ -33,9 +40,7 @@ export function createContext<P extends Record<string, string>>(
     data,
     req: {
       raw: request,
-      param(name?: string) {
-        return name ? params[name] : params;
-      },
+      param,
     },
     executionCtx: {
       waitUntil,

--- a/tests/manage-read-endpoints.test.ts
+++ b/tests/manage-read-endpoints.test.ts
@@ -122,7 +122,7 @@ describe("manage read endpoints", () => {
   it("enforces admin manage JWT IP and user-agent binding", async () => {
     await seedEventAndAdmin(env.DB);
     const admin = (await queryAll<{ id: string }>(env.DB, "SELECT id FROM users WHERE role = 'admin' LIMIT 1"))[0];
-    await createAdminSession(env.DB, admin.id, "admin-manage-token");
+    const adminToken = await createAdminSession(env.DB, admin.id, "admin-manage-token");
 
     await env.DB.prepare(
       `
@@ -146,7 +146,7 @@ describe("manage read endpoints", () => {
         new Request("https://app.test/api/v1/admin/events/pqc-2026/registrations/open-manage", {
           method: "POST",
           headers: {
-            authorization: "Bearer admin-manage-token",
+            authorization: `Bearer ${adminToken}`,
             "cf-connecting-ip": "203.0.113.30",
             "user-agent": "admin-browser",
           },

--- a/tests/proposal-participants.test.ts
+++ b/tests/proposal-participants.test.ts
@@ -147,13 +147,13 @@ describe("proposal participants", () => {
     )[0];
     expect(pendingParticipant.status).toBe("inactive");
 
-    await createAdminSession(env.DB, adminRow.id, "token-admin-badge-role");
+    const adminToken = await createAdminSession(env.DB, adminRow.id, "token-admin-badge-role");
 
     const pendingResponse = await getBadgeRole(
       createContext(
         env,
         new Request(`https://app.test/api/v1/admin/events/pqc-2026/registrations/${registrationId}/badge-role`, {
-          headers: { authorization: "Bearer token-admin-badge-role" },
+          headers: { authorization: `Bearer ${adminToken}` },
         }),
         { eventSlug: "pqc-2026", registrationId },
       ),
@@ -187,7 +187,7 @@ describe("proposal participants", () => {
       createContext(
         env,
         new Request(`https://app.test/api/v1/admin/events/pqc-2026/registrations/${registrationId}/badge-role`, {
-          headers: { authorization: "Bearer token-admin-badge-role" },
+          headers: { authorization: `Bearer ${adminToken}` },
         }),
         { eventSlug: "pqc-2026", registrationId },
       ),

--- a/tests/proposal-review.test.ts
+++ b/tests/proposal-review.test.ts
@@ -54,7 +54,7 @@ describe("proposal review and finalize", () => {
     const { eventId } = await seedEventAndAdmin(env.DB);
     const { proposalId, admin1Id } = await seedProposal(env.DB, eventId);
 
-    await createAdminSession(env.DB, admin1Id, "token-admin-1");
+    const admin1Token = await createAdminSession(env.DB, admin1Id, "token-admin-1");
 
     const createResponse = await upsertReview(
       createContext(
@@ -63,7 +63,7 @@ describe("proposal review and finalize", () => {
           method: "POST",
           headers: {
             "content-type": "application/json",
-            authorization: "Bearer token-admin-1",
+            authorization: `Bearer ${admin1Token}`,
           },
           body: JSON.stringify({ recommendation: "accept", score: 9, reviewerComment: "Good" }),
         }),
@@ -91,7 +91,7 @@ describe("proposal review and finalize", () => {
           method: "POST",
           headers: {
             "content-type": "application/json",
-            authorization: "Bearer token-admin-1",
+            authorization: `Bearer ${admin1Token}`,
           },
           body: JSON.stringify({ recommendation: "accept", score: 9, reviewerComment: "Good" }),
         }),
@@ -120,7 +120,7 @@ describe("proposal review and finalize", () => {
           method: "PATCH",
           headers: {
             "content-type": "application/json",
-            authorization: "Bearer token-admin-1",
+            authorization: `Bearer ${admin1Token}`,
           },
           body: JSON.stringify({ score: 10, reviewerComment: "Excellent", applicantNote: "Ready for acceptance" }),
         }),
@@ -146,8 +146,8 @@ describe("proposal review and finalize", () => {
     const { eventId } = await seedEventAndAdmin(env.DB);
     const { proposalId, admin1Id, admin2Id } = await seedProposal(env.DB, eventId);
 
-    await createAdminSession(env.DB, admin1Id, "token-admin-1");
-    await createAdminSession(env.DB, admin2Id, "token-admin-2");
+    const admin1Token = await createAdminSession(env.DB, admin1Id, "token-admin-1");
+    const admin2Token = await createAdminSession(env.DB, admin2Id, "token-admin-2");
 
     await upsertReview(
       createContext(
@@ -156,7 +156,7 @@ describe("proposal review and finalize", () => {
           method: "POST",
           headers: {
             "content-type": "application/json",
-            authorization: "Bearer token-admin-1",
+            authorization: `Bearer ${admin1Token}`,
           },
           body: JSON.stringify({ recommendation: "accept", score: 9, reviewerComment: "Good" }),
         }),
@@ -172,7 +172,7 @@ describe("proposal review and finalize", () => {
             method: "POST",
             headers: {
               "content-type": "application/json",
-              authorization: "Bearer token-admin-1",
+              authorization: `Bearer ${admin1Token}`,
             },
             body: JSON.stringify({ finalStatus: "accepted", minReviewsRequired: 2 }),
           }),
@@ -188,7 +188,7 @@ describe("proposal review and finalize", () => {
           method: "POST",
           headers: {
             "content-type": "application/json",
-            authorization: "Bearer token-admin-2",
+            authorization: `Bearer ${admin2Token}`,
           },
           body: JSON.stringify({ recommendation: "accept", score: 8, reviewerComment: "Also good" }),
         }),
@@ -203,7 +203,7 @@ describe("proposal review and finalize", () => {
           method: "POST",
           headers: {
             "content-type": "application/json",
-            authorization: "Bearer token-admin-1",
+            authorization: `Bearer ${admin1Token}`,
           },
           body: JSON.stringify({ finalStatus: "accepted", minReviewsRequired: 2 }),
         }),

--- a/tests/speaker-management.test.ts
+++ b/tests/speaker-management.test.ts
@@ -77,8 +77,7 @@ async function setupWorkflow() {
   const { eventId } = await seedEventAndAdmin(env.DB);
   const adminUser = (await queryAll<{ id: string }>(env.DB, "SELECT id FROM users WHERE role = 'admin' LIMIT 1"))[0];
   await seedWorkflowEmailTemplates(env.DB, adminUser.id);
-  await createAdminSession(env.DB, adminUser.id, "test-admin-token");
-  adminSessionToken = "test-admin-token";
+  adminSessionToken = await createAdminSession(env.DB, adminUser.id, "test-admin-token");
   return { eventId, adminUserId: adminUser.id };
 }
 


### PR DESCRIPTION
- Add D1 Sessions API helpers (functions/_lib/db/session.ts)
- Implement request-scoped admin auth caching with WeakMap
- Add middleware to route admin GET/HEAD reads through replicas
- Maintain primary-first auth and primary-only mutations
- Add comprehensive test coverage for replication routing