### PR TITLE
Remove stray PKIMM version switcher copy from the section nav

### DIFF
--- a/layouts/partials/wg/sub-navigation.html
+++ b/layouts/partials/wg/sub-navigation.html
@@ -172,10 +172,6 @@
     {{ end }}
 
     <a class="wg-nav-link" href="/blog/?wg={{ $wg.Params.wgID | lower }}">Blog</a>
-
-    {{ if eq ($wg.Params.wgID | upper) "PKIMM" }}
-    {{ partial "wg/pkimm-version-switcher.html" . }}
-    {{ end }}
   </div>
 </nav>
 {{/* Tree panels — one per deliverable section with child pages */}}


### PR DESCRIPTION
Accidentally re-introduced in #594 alongside unrelated member-domain changes. The switcher already renders correctly inside the Model tree panel (#597) and the side menu (#600); the inline-in-nav copy doesn't fit the section nav's horizontal layout, so its styling looks broken and it sits in the wrong place.