### PR TITLE
Add proposal review drafts and MCP scaffold

### DIFF
--- a/assets/shared/schemas/api.ts
+++ b/assets/shared/schemas/api.ts
@@ -312,6 +312,7 @@ export const proposalManageSchema = boundedJsonObject(
 export const reviewUpsertSchema = z.object({
   recommendation: z.enum(["accept", "reject", "needs-work"]),
   score: z.number().int().min(1).max(10),
+  status: z.enum(["draft", "submitted"]).optional().default("submitted"),
   reviewerComment: z.preprocess(
     (value) => (typeof value === "string" && value.trim() === "" ? undefined : value),
     trimmedString(3, 10_000).optional(),
@@ -325,6 +326,7 @@ export const reviewUpsertSchema = z.object({
 export const reviewPatchSchema = z.object({
   recommendation: z.enum(["accept", "reject", "needs-work"]).optional(),
   score: z.number().int().min(1).max(10).nullable().optional(),
+  status: z.enum(["draft", "submitted"]).optional(),
   reviewerComment: z.preprocess(
     (value) => (typeof value === "string" && value.trim() === "" ? null : value),
     trimmedString(3, 10_000).nullable().optional(),

--- a/assets/ts/admin/App.tsx
+++ b/assets/ts/admin/App.tsx
@@ -1,6 +1,72 @@
-import { isAuthed } from "./state";
+import { useEffect, useState } from "preact/hooks";
+import { authToken, isAuthed } from "./state";
 import { Login } from "./shell/Login";
 import { AdminShell } from "./shell/AdminShell";
+
+function McpAuthorize() {
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const params = new URLSearchParams(window.location.search);
+  const encoded = params.get("mcp_authorize") ?? "";
+  const payload = (() => {
+    try {
+      return JSON.parse(atob(encoded)) as Record<string, string>;
+    } catch {
+      return null;
+    }
+  })();
+
+  useEffect(() => {
+    if (!payload) {
+      setError("Invalid MCP authorization request.");
+    }
+  }, [payload]);
+
+  async function approve(): Promise<void> {
+    if (!payload) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/mcp/oauth/authorize/approve", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${authToken.value}`,
+        },
+        body: JSON.stringify(payload),
+      });
+      const data: { redirectTo?: string; error_description?: string } = await res.json().catch(() => ({}));
+      if (!res.ok || !data.redirectTo) {
+        throw new Error(data.error_description ?? "Unable to authorize the MCP client.");
+      }
+      window.location.href = data.redirectTo;
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : "Unable to authorize the MCP client.");
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div id="verify-overlay">
+      {error ? (
+        <div class="alert alert-danger mb-0">Authorization failed: {error}</div>
+      ) : (
+        <div class="text-center">
+          <h2 class="h5 mb-3">Authorize Claude</h2>
+          <p class="text-muted">Allow this MCP client to read event proposals and save abstract reviews.</p>
+          <button
+            class="btn btn-success"
+            type="button"
+            disabled={submitting || !payload}
+            onClick={() => void approve()}
+          >
+            {submitting ? "Authorizing..." : "Authorize"}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
 
 /**
  * Root component — gates on auth state.
@@ -10,5 +76,8 @@ import { AdminShell } from "./shell/AdminShell";
  * without a full page reload.
  */
 export function App() {
+  if (isAuthed.value && new URLSearchParams(window.location.search).has("mcp_authorize")) {
+    return <McpAuthorize />;
+  }
   return isAuthed.value ? <AdminShell /> : <Login />;
 }

--- a/assets/ts/admin/sections/events/detail/ProposalDetailPage.tsx
+++ b/assets/ts/admin/sections/events/detail/ProposalDetailPage.tsx
@@ -410,6 +410,7 @@ function ReviewCard({ review }: { review: ProposalReview }) {
       <div class="card-body py-2 px-3">
         <div class="d-flex gap-2 align-items-center mb-2 flex-wrap">
           <span class={`badge text-bg-${recColour}`}>{review.recommendation}</span>
+          {review.status === "draft" && <span class="badge text-bg-secondary">Draft</span>}
           {review.score != null && <span class="badge text-bg-light border text-body">Score {review.score}/10</span>}
           <span class="small text-muted">{reviewer}</span>
           <span class="small text-muted ms-auto">{fmt(review.updated_at)}</span>
@@ -512,7 +513,9 @@ export function ProposalDetailPage({ slug, proposalId }: { slug: string; proposa
   const { proposal, access, form, minReviewsRequired } = data;
   const proposer =
     [proposal.proposer_first_name, proposal.proposer_last_name].filter(Boolean).join(" ") || proposal.proposer_email;
-  const quorumMet = reviews.length >= minReviewsRequired;
+  const submittedReviewCount = reviews.filter((review) => review.status === "submitted").length;
+  const myReview = reviews.find((review) => review.reviewer_email === authEmail.value);
+  const quorumMet = submittedReviewCount >= minReviewsRequired;
   const needsWorkRequiresNote = isNeedsWorkDecision(decisionStatus) && !decisionNote.trim();
   const selectedDecisionPreview =
     decisionPreview?.messages.find((message) => message.id === selectedDecisionPreviewId) ??
@@ -543,7 +546,7 @@ export function ProposalDetailPage({ slug, proposalId }: { slug: string; proposa
   const tabItems = [
     { key: "submission", label: "Submission" },
     { key: "speakers", label: `Speakers (${loadingSub ? "…" : speakers.length})` },
-    { key: "reviews", label: `Reviews (${loadingSub ? "…" : reviews.length})` },
+    { key: "reviews", label: `Reviews (${loadingSub ? "…" : submittedReviewCount})` },
     { key: "audit-log", label: "Audit Log" },
     ...(access.canFinalize ? [{ key: "decision", label: "Decision" }] : []),
   ];
@@ -578,12 +581,12 @@ export function ProposalDetailPage({ slug, proposalId }: { slug: string; proposa
     }
   }
 
-  async function handleReview(e: Event) {
+  async function handleReview(e: Event, status: "draft" | "submitted" = "submitted") {
     e.preventDefault();
     setSavingReview(true);
     try {
       const score = parseInt(reviewScore, 10);
-      const body: Record<string, unknown> = { recommendation: reviewRec, score };
+      const body: Record<string, unknown> = { recommendation: reviewRec, score, status };
       if (reviewComment.trim()) body.reviewerComment = reviewComment.trim();
       if (reviewApplicantNote.trim()) body.applicantNote = reviewApplicantNote.trim();
       const result = await api<{ review: ProposalReview }>(`/api/v1/admin/proposals/${proposalId}/reviews`, {
@@ -594,7 +597,7 @@ export function ProposalDetailPage({ slug, proposalId }: { slug: string; proposa
         const idx = prev.findIndex((r) => r.reviewer_user_id === result.review.reviewer_user_id);
         return idx >= 0 ? prev.map((r, i) => (i === idx ? result.review : r)) : [...prev, result.review];
       });
-      toast("Review saved", "success");
+      toast(status === "draft" ? "Review draft saved" : "Review submitted", "success");
       void reload();
     } catch (err) {
       toast((err as Error).message, "error");
@@ -693,7 +696,7 @@ export function ProposalDetailPage({ slug, proposalId }: { slug: string; proposa
           <div class="card card-body p-3 h-100">
             <div class="small text-muted mb-1">Reviews</div>
             <div>
-              {loadingSub ? "…" : reviews.length} / {minReviewsRequired} required
+              {loadingSub ? "…" : submittedReviewCount} / {minReviewsRequired} required
             </div>
             <div class={`small ${quorumMet ? "text-success" : "text-warning"}`}>
               {quorumMet ? "Quorum met ✓" : "Quorum not met"}
@@ -811,13 +814,13 @@ export function ProposalDetailPage({ slug, proposalId }: { slug: string; proposa
                   <div class="d-flex align-items-center gap-3 flex-wrap">
                     <span class="text-muted small">Review progress</span>
                     <strong class="small">
-                      {loadingSub ? "…" : reviews.length} / {minReviewsRequired}
+                      {loadingSub ? "…" : submittedReviewCount} / {minReviewsRequired}
                     </strong>
                     {quorumMet ? (
                       <span class="badge text-bg-success">Quorum met</span>
                     ) : (
                       <span class="badge text-bg-warning">
-                        {minReviewsRequired - (loadingSub ? 0 : reviews.length)} more needed
+                        {minReviewsRequired - (loadingSub ? 0 : submittedReviewCount)} more needed
                       </span>
                     )}
                   </div>
@@ -836,11 +839,15 @@ export function ProposalDetailPage({ slug, proposalId }: { slug: string; proposa
                 <div class="card mt-3">
                   <div class="card-header">
                     <h6 class="mb-0">
-                      {reviews.some((r) => r.reviewer_email === authEmail.value) ? "Edit My Review" : "Add Review"}
+                      {myReview?.status === "submitted"
+                        ? "Edit My Review"
+                        : myReview?.status === "draft"
+                          ? "Edit My Draft"
+                          : "Add Review"}
                     </h6>
                   </div>
                   <div class="card-body">
-                    <form onSubmit={(e) => void handleReview(e)}>
+                    <form onSubmit={(e) => void handleReview(e, "submitted")}>
                       <div class="row g-3">
                         <div class="col-md-5">
                           <label class="form-label fw-semibold">Recommendation</label>
@@ -896,9 +903,21 @@ export function ProposalDetailPage({ slug, proposalId }: { slug: string; proposa
                             placeholder="Feedback or clarification request for the applicant…"
                           />
                         </div>
-                        <div class="col-12">
+                        <div class="col-12 d-flex gap-2 flex-wrap">
+                          <button
+                            type="button"
+                            class="btn btn-outline-secondary"
+                            disabled={savingReview}
+                            onClick={(e) => void handleReview(e, "draft")}
+                          >
+                            {savingReview ? "Saving…" : "Save Draft"}
+                          </button>
                           <button type="submit" class="btn btn-primary" disabled={savingReview}>
-                            {savingReview ? "Saving…" : "Submit Review"}
+                            {savingReview
+                              ? "Saving…"
+                              : myReview?.status === "submitted"
+                                ? "Update Review"
+                                : "Submit Review"}
                           </button>
                         </div>
                       </div>
@@ -943,7 +962,7 @@ export function ProposalDetailPage({ slug, proposalId }: { slug: string; proposa
                   <>
                     {!quorumMet && !loadingSub && (
                       <div class="alert alert-warning">
-                        <strong>Quorum not met.</strong> {reviews.length} of {minReviewsRequired} required review
+                        <strong>Quorum not met.</strong> {submittedReviewCount} of {minReviewsRequired} required review
                         {minReviewsRequired !== 1 ? "s" : ""} completed. Add more reviews before finalizing.
                       </div>
                     )}
@@ -1142,7 +1161,7 @@ export function ProposalDetailPage({ slug, proposalId }: { slug: string; proposa
                 </dd>
                 <dt>Reviews</dt>
                 <dd class="mb-2">
-                  {loadingSub ? "…" : reviews.length} / {minReviewsRequired} required
+                  {loadingSub ? "…" : submittedReviewCount} / {minReviewsRequired} required
                 </dd>
                 <dt>Last updated</dt>
                 <dd class="mb-0">{fmt(proposal.updated_at)}</dd>

--- a/assets/ts/admin/shell/Login.tsx
+++ b/assets/ts/admin/shell/Login.tsx
@@ -1,6 +1,8 @@
 import { useState } from "preact/hooks";
 import { saveAuth } from "../state";
 
+const MCP_AUTHORIZE_STORAGE_KEY = "pkic_mcp_authorize";
+
 async function requestMagicLink(email: string): Promise<void> {
   await fetch("/api/v1/admin/auth/request-link", {
     method: "POST",
@@ -23,10 +25,20 @@ async function verifyMagicLink(token: string): Promise<void> {
     throw new Error(d.error?.message ?? "The link may have expired or already been used.");
   }
   saveAuth(d.token!, d.admin?.email ?? null);
+  const pendingMcpAuthorize = localStorage.getItem(MCP_AUTHORIZE_STORAGE_KEY);
+  if (pendingMcpAuthorize) {
+    localStorage.removeItem(MCP_AUTHORIZE_STORAGE_KEY);
+    history.replaceState({}, "", `/admin/?mcp_authorize=${encodeURIComponent(pendingMcpAuthorize)}`);
+    return;
+  }
   history.replaceState({}, "", "/admin/");
 }
 
 export function Login() {
+  const pendingMcpAuthorize = new URLSearchParams(window.location.search).get("mcp_authorize");
+  if (pendingMcpAuthorize) {
+    localStorage.setItem(MCP_AUTHORIZE_STORAGE_KEY, pendingMcpAuthorize);
+  }
   const [sent, setSent] = useState(false);
   const [verifying, setVerifying] = useState(() => Boolean(new URLSearchParams(window.location.search).get("token")));
   const [error, setError] = useState<string | null>(null);

--- a/assets/ts/admin/types.ts
+++ b/assets/ts/admin/types.ts
@@ -163,9 +163,11 @@ export interface ProposalReview {
   id: string;
   reviewer_user_id: string;
   recommendation: "accept" | "reject" | "needs-work";
+  status: "draft" | "submitted";
   score: number | null;
   reviewer_comment: string | null;
   applicant_note: string | null;
+  submitted_at: string | null;
   updated_at: string;
   reviewer_email?: string;
   reviewer_first_name?: string | null;

--- a/functions/_lib/services/proposals.ts
+++ b/functions/_lib/services/proposals.ts
@@ -821,11 +821,7 @@ export async function updateReviewById(
 
   params.push(reviewId);
 
-  await run(
-    db,
-    `UPDATE proposal_reviews SET ${fields.join(", ")} WHERE id = ?`,
-    params,
-  );
+  await run(db, `UPDATE proposal_reviews SET ${fields.join(", ")} WHERE id = ?`, params);
 
   const updated = await first<ProposalReviewRecord>(db, "SELECT * FROM proposal_reviews WHERE id = ?", [reviewId]);
   if (!updated) {

--- a/functions/_lib/services/proposals.ts
+++ b/functions/_lib/services/proposals.ts
@@ -32,9 +32,11 @@ export interface ProposalReviewRecord {
   proposal_id: string;
   reviewer_user_id: string;
   recommendation: "accept" | "reject" | "needs-work";
+  status: "draft" | "submitted";
   score: number | null;
   reviewer_comment: string | null;
   applicant_note: string | null;
+  submitted_at: string | null;
   created_at: string;
   updated_at: string;
   reviewer_email?: string;
@@ -651,12 +653,15 @@ export async function upsertProposalReview(
     proposalId: string;
     reviewerUserId: string;
     recommendation: "accept" | "reject" | "needs-work";
+    status?: "draft" | "submitted";
     score?: number | null;
     reviewerComment?: string | null;
     applicantNote?: string | null;
   },
 ): Promise<ProposalReviewRecord> {
   const now = nowIso();
+  const status = payload.status ?? "submitted";
+  const submittedAt = status === "submitted" ? now : null;
   const existing = await first<ProposalReviewRecord>(
     db,
     `SELECT * FROM proposal_reviews
@@ -670,9 +675,11 @@ export async function upsertProposalReview(
       proposal_id: payload.proposalId,
       reviewer_user_id: payload.reviewerUserId,
       recommendation: payload.recommendation,
+      status,
       score: payload.score ?? null,
       reviewer_comment: payload.reviewerComment ?? null,
       applicant_note: payload.applicantNote ?? null,
+      submitted_at: submittedAt,
       created_at: now,
       updated_at: now,
     };
@@ -680,17 +687,19 @@ export async function upsertProposalReview(
     await run(
       db,
       `INSERT INTO proposal_reviews (
-        id, proposal_id, reviewer_user_id, recommendation, score,
-        reviewer_comment, applicant_note, created_at, updated_at
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        id, proposal_id, reviewer_user_id, recommendation, status, score,
+        reviewer_comment, applicant_note, submitted_at, created_at, updated_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       [
         review.id,
         review.proposal_id,
         review.reviewer_user_id,
         review.recommendation,
+        review.status,
         review.score,
         review.reviewer_comment,
         review.applicant_note,
+        review.submitted_at,
         review.created_at,
         review.updated_at,
       ],
@@ -702,13 +711,15 @@ export async function upsertProposalReview(
   await run(
     db,
     `UPDATE proposal_reviews
-     SET recommendation = ?, score = ?, reviewer_comment = ?, applicant_note = ?, updated_at = ?
+     SET recommendation = ?, status = ?, score = ?, reviewer_comment = ?, applicant_note = ?, submitted_at = ?, updated_at = ?
      WHERE id = ?`,
     [
       payload.recommendation,
+      status,
       payload.score ?? null,
       payload.reviewerComment ?? null,
       payload.applicantNote ?? null,
+      status === "submitted" ? (existing.submitted_at ?? now) : null,
       now,
       existing.id,
     ],
@@ -725,12 +736,14 @@ export async function upsertProposalReview(
 export function buildProposalReviewAuditDetails(
   before: {
     recommendation: string | null;
+    status: string | null;
     score: number | null;
     reviewerComment: string | null;
     applicantNote: string | null;
   },
   after: {
     recommendation: string | null;
+    status: string | null;
     score: number | null;
     reviewerComment: string | null;
     applicantNote: string | null;
@@ -768,6 +781,7 @@ export async function updateReviewById(
   reviewId: string,
   payload: {
     recommendation?: "accept" | "reject" | "needs-work";
+    status?: "draft" | "submitted";
     score?: number | null;
     reviewerComment?: string | null;
     applicantNote?: string | null;
@@ -778,21 +792,29 @@ export async function updateReviewById(
     throw new AppError(404, "PROPOSAL_REVIEW_NOT_FOUND", "Proposal review not found");
   }
 
+  const now = nowIso();
+  const status = payload.status ?? existing.status;
+  const submittedAt = status === "submitted" ? (existing.submitted_at ?? now) : null;
+
   await run(
     db,
     `UPDATE proposal_reviews
      SET recommendation = COALESCE(?, recommendation),
+         status = ?,
          score = COALESCE(?, score),
          reviewer_comment = COALESCE(?, reviewer_comment),
          applicant_note = COALESCE(?, applicant_note),
+         submitted_at = ?,
          updated_at = ?
      WHERE id = ?`,
     [
       payload.recommendation ?? null,
+      status,
       payload.score ?? null,
       payload.reviewerComment ?? null,
       payload.applicantNote ?? null,
-      nowIso(),
+      submittedAt,
+      now,
       reviewId,
     ],
   );
@@ -825,7 +847,7 @@ export async function finalizeProposalDecision(
 
   const reviewCountRow = await first<{ total: number }>(
     db,
-    "SELECT COUNT(*) AS total FROM proposal_reviews WHERE proposal_id = ?",
+    "SELECT COUNT(*) AS total FROM proposal_reviews WHERE proposal_id = ? AND status = 'submitted'",
     [payload.proposalId],
   );
   const reviewCount = Number(reviewCountRow?.total ?? 0);
@@ -915,6 +937,7 @@ export async function listProposalsForEvent(db: DatabaseLike, eventId: string): 
      LEFT JOIN (
        SELECT proposal_id, COUNT(*) AS review_count
        FROM proposal_reviews
+       WHERE status = 'submitted'
        GROUP BY proposal_id
      ) rv ON rv.proposal_id = sp.id
      LEFT JOIN proposal_decisions pd ON pd.proposal_id = sp.id

--- a/functions/_lib/services/proposals.ts
+++ b/functions/_lib/services/proposals.ts
@@ -796,27 +796,35 @@ export async function updateReviewById(
   const status = payload.status ?? existing.status;
   const submittedAt = status === "submitted" ? (existing.submitted_at ?? now) : null;
 
+  const fields: string[] = ["status = ?", "submitted_at = ?", "updated_at = ?"];
+  const params: Array<string | number | null> = [status, submittedAt, now];
+
+  if (payload.recommendation !== undefined) {
+    fields.push("recommendation = ?");
+    params.push(payload.recommendation);
+  }
+
+  if (payload.score !== undefined) {
+    fields.push("score = ?");
+    params.push(payload.score);
+  }
+
+  if (payload.reviewerComment !== undefined) {
+    fields.push("reviewer_comment = ?");
+    params.push(payload.reviewerComment);
+  }
+
+  if (payload.applicantNote !== undefined) {
+    fields.push("applicant_note = ?");
+    params.push(payload.applicantNote);
+  }
+
+  params.push(reviewId);
+
   await run(
     db,
-    `UPDATE proposal_reviews
-     SET recommendation = COALESCE(?, recommendation),
-         status = ?,
-         score = COALESCE(?, score),
-         reviewer_comment = COALESCE(?, reviewer_comment),
-         applicant_note = COALESCE(?, applicant_note),
-         submitted_at = ?,
-         updated_at = ?
-     WHERE id = ?`,
-    [
-      payload.recommendation ?? null,
-      status,
-      payload.score ?? null,
-      payload.reviewerComment ?? null,
-      payload.applicantNote ?? null,
-      submittedAt,
-      now,
-      reviewId,
-    ],
+    `UPDATE proposal_reviews SET ${fields.join(", ")} WHERE id = ?`,
+    params,
   );
 
   const updated = await first<ProposalReviewRecord>(db, "SELECT * FROM proposal_reviews WHERE id = ?", [reviewId]);

--- a/functions/api/mcp/router.ts
+++ b/functions/api/mcp/router.ts
@@ -1,0 +1,157 @@
+import { Hono } from "hono";
+import { jsonNoStore } from "../../_lib/http";
+
+type McpProfile = "all" | "events";
+
+interface JsonRpcRequest {
+  jsonrpc?: string;
+  id?: string | number | null;
+  method?: string;
+}
+
+interface McpToolDefinition {
+  name: string;
+  description: string;
+  inputSchema: {
+    type: "object";
+    properties: Record<string, unknown>;
+    required?: string[];
+  };
+}
+
+const eventTools: McpToolDefinition[] = [
+  {
+    name: "events.list",
+    description: "List events the authenticated user can access.",
+    inputSchema: { type: "object", properties: {} },
+  },
+  {
+    name: "events.proposals.list",
+    description: "List event proposals visible to the authenticated reviewer.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        eventSlug: { type: "string" },
+        status: { type: "string" },
+        reviewStatus: { type: "string", enum: ["draft", "submitted"] },
+      },
+      required: ["eventSlug"],
+    },
+  },
+  {
+    name: "events.proposals.read",
+    description: "Read one proposal, including abstract and review metadata.",
+    inputSchema: {
+      type: "object",
+      properties: { proposalId: { type: "string" } },
+      required: ["proposalId"],
+    },
+  },
+  {
+    name: "events.reviews.getMine",
+    description: "Read the authenticated user's review or draft for a proposal.",
+    inputSchema: {
+      type: "object",
+      properties: { proposalId: { type: "string" } },
+      required: ["proposalId"],
+    },
+  },
+  {
+    name: "events.reviews.saveDraft",
+    description: "Save a complete draft review for the authenticated reviewer.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        proposalId: { type: "string" },
+        recommendation: { type: "string", enum: ["accept", "reject", "needs-work"] },
+        score: { type: "integer", minimum: 1, maximum: 10 },
+        reviewerComment: { type: "string" },
+        applicantNote: { type: "string" },
+      },
+      required: ["proposalId", "recommendation", "score"],
+    },
+  },
+  {
+    name: "events.reviews.submit",
+    description: "Submit a complete review as the authenticated reviewer.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        proposalId: { type: "string" },
+        recommendation: { type: "string", enum: ["accept", "reject", "needs-work"] },
+        score: { type: "integer", minimum: 1, maximum: 10 },
+        reviewerComment: { type: "string" },
+        applicantNote: { type: "string" },
+      },
+      required: ["proposalId", "recommendation", "score"],
+    },
+  },
+];
+
+function toolsForProfile(profile: McpProfile): McpToolDefinition[] {
+  if (profile === "events") {
+    return eventTools;
+  }
+  return eventTools;
+}
+
+function discovery(profile: McpProfile): Record<string, unknown> {
+  return {
+    name: profile === "events" ? "PKI Consortium Events MCP" : "PKI Consortium MCP",
+    profile,
+    transport: "streamable-http",
+    endpoints: {
+      all: "/api/mcp",
+      events: "/api/mcp/events",
+    },
+    capabilities: {
+      tools: true,
+    },
+    tools: toolsForProfile(profile),
+  };
+}
+
+function jsonRpcResult(request: JsonRpcRequest, result: unknown): Response {
+  return jsonNoStore({ jsonrpc: "2.0", id: request.id ?? null, result });
+}
+
+function jsonRpcError(request: JsonRpcRequest, code: number, message: string): Response {
+  return jsonNoStore({ jsonrpc: "2.0", id: request.id ?? null, error: { code, message } });
+}
+
+async function handleMcpPost(request: Request, profile: McpProfile): Promise<Response> {
+  const body = (await request.json().catch(() => null)) as JsonRpcRequest | null;
+  if (!body || body.jsonrpc !== "2.0" || typeof body.method !== "string") {
+    return jsonRpcError({ id: null }, -32600, "Invalid JSON-RPC request");
+  }
+
+  if (body.method === "initialize") {
+    return jsonRpcResult(body, {
+      protocolVersion: "2025-06-18",
+      capabilities: { tools: {} },
+      serverInfo: {
+        name: profile === "events" ? "pkic-events" : "pkic",
+        version: "0.1.0",
+      },
+    });
+  }
+
+  if (body.method === "tools/list") {
+    return jsonRpcResult(body, { tools: toolsForProfile(profile) });
+  }
+
+  if (body.method === "tools/call") {
+    return jsonRpcError(body, -32601, "MCP tool execution is not implemented yet");
+  }
+
+  return jsonRpcError(body, -32601, "Method not found");
+}
+
+const app = new Hono();
+
+app.get("/", () => jsonNoStore(discovery("all")));
+app.post("/", (c) => handleMcpPost(c.req.raw, "all"));
+app.get("/events", () => jsonNoStore(discovery("events")));
+app.post("/events", (c) => handleMcpPost(c.req.raw, "events"));
+
+export default app;

--- a/functions/api/mcp/router.ts
+++ b/functions/api/mcp/router.ts
@@ -21,12 +21,12 @@ interface McpToolDefinition {
 
 const eventTools: McpToolDefinition[] = [
   {
-    name: "events.list",
+    name: "events_list",
     description: "List events the authenticated user can access.",
     inputSchema: { type: "object", properties: {} },
   },
   {
-    name: "events.proposals.list",
+    name: "events_proposals_list",
     description: "List event proposals visible to the authenticated reviewer.",
     inputSchema: {
       type: "object",
@@ -39,7 +39,7 @@ const eventTools: McpToolDefinition[] = [
     },
   },
   {
-    name: "events.proposals.read",
+    name: "events_proposals_read",
     description: "Read one proposal, including abstract and review metadata.",
     inputSchema: {
       type: "object",
@@ -48,7 +48,7 @@ const eventTools: McpToolDefinition[] = [
     },
   },
   {
-    name: "events.reviews.getMine",
+    name: "events_reviews_get_mine",
     description: "Read the authenticated user's review or draft for a proposal.",
     inputSchema: {
       type: "object",
@@ -57,7 +57,7 @@ const eventTools: McpToolDefinition[] = [
     },
   },
   {
-    name: "events.reviews.saveDraft",
+    name: "events_reviews_save_draft",
     description: "Save a complete draft review for the authenticated reviewer.",
     inputSchema: {
       type: "object",
@@ -72,7 +72,7 @@ const eventTools: McpToolDefinition[] = [
     },
   },
   {
-    name: "events.reviews.submit",
+    name: "events_reviews_submit",
     description: "Submit a complete review as the authenticated reviewer.",
     inputSchema: {
       type: "object",

--- a/functions/api/mcp/router.ts
+++ b/functions/api/mcp/router.ts
@@ -1,114 +1,119 @@
 import { Hono } from "hono";
 import { jsonNoStore } from "../../_lib/http";
+import { requireAdminFromRequest, getAdminBySessionClaims, type AdminSessionTokenClaims } from "../../_lib/auth/admin";
+import { getProposalAccessForEvent } from "../../_lib/auth/proposal-access";
+import { getEventBySlug } from "../../_lib/services/events";
+import {
+  buildProposalReviewAuditDetails,
+  listProposalReviews,
+  upsertProposalReview,
+  type ProposalListRecord,
+  type ProposalRecord,
+  type ProposalReviewRecord,
+} from "../../_lib/services/proposals";
+import { writeAuditLog } from "../../_lib/services/audit";
+import { all, first, run } from "../../_lib/db/queries";
+import { signJwt, verifyJwt } from "../../_lib/utils/jwt";
+import { sha256Hex } from "../../_lib/utils/crypto";
+import { addHours, nowIso } from "../../_lib/utils/time";
+import { uuid } from "../../_lib/utils/ids";
+import { AppError, isAppError } from "../../_lib/errors";
+import { discovery, toolsForProfile } from "./tools";
+import type { AuthAdmin, Env } from "../../_lib/types";
 
-type McpProfile = "all" | "events";
+export type McpProfile = "all" | "events";
+type Recommendation = "accept" | "reject" | "needs-work";
+type ReviewStatus = "draft" | "submitted";
 
 interface JsonRpcRequest {
   jsonrpc?: string;
   id?: string | number | null;
   method?: string;
+  params?: unknown;
 }
 
-interface McpToolDefinition {
-  name: string;
-  description: string;
-  inputSchema: {
-    type: "object";
-    properties: Record<string, unknown>;
-    required?: string[];
-  };
+interface McpToolCallParams {
+  name?: string;
+  arguments?: Record<string, unknown>;
 }
 
-const eventTools: McpToolDefinition[] = [
-  {
-    name: "events_list",
-    description: "List events the authenticated user can access.",
-    inputSchema: { type: "object", properties: {} },
-  },
-  {
-    name: "events_proposals_list",
-    description: "List event proposals visible to the authenticated reviewer.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        eventSlug: { type: "string" },
-        status: { type: "string" },
-        reviewStatus: { type: "string", enum: ["draft", "submitted"] },
-      },
-      required: ["eventSlug"],
-    },
-  },
-  {
-    name: "events_proposals_read",
-    description: "Read one proposal, including abstract and review metadata.",
-    inputSchema: {
-      type: "object",
-      properties: { proposalId: { type: "string" } },
-      required: ["proposalId"],
-    },
-  },
-  {
-    name: "events_reviews_get_mine",
-    description: "Read the authenticated user's review or draft for a proposal.",
-    inputSchema: {
-      type: "object",
-      properties: { proposalId: { type: "string" } },
-      required: ["proposalId"],
-    },
-  },
-  {
-    name: "events_reviews_save_draft",
-    description: "Save a complete draft review for the authenticated reviewer.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        proposalId: { type: "string" },
-        recommendation: { type: "string", enum: ["accept", "reject", "needs-work"] },
-        score: { type: "integer", minimum: 1, maximum: 10 },
-        reviewerComment: { type: "string" },
-        applicantNote: { type: "string" },
-      },
-      required: ["proposalId", "recommendation", "score"],
-    },
-  },
-  {
-    name: "events_reviews_submit",
-    description: "Submit a complete review as the authenticated reviewer.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        proposalId: { type: "string" },
-        recommendation: { type: "string", enum: ["accept", "reject", "needs-work"] },
-        score: { type: "integer", minimum: 1, maximum: 10 },
-        reviewerComment: { type: "string" },
-        applicantNote: { type: "string" },
-      },
-      required: ["proposalId", "recommendation", "score"],
-    },
-  },
-];
-
-function toolsForProfile(profile: McpProfile): McpToolDefinition[] {
-  if (profile === "events") {
-    return eventTools;
-  }
-  return eventTools;
+interface OAuthCodeClaims {
+  typ: "mcp-oauth-code";
+  sub: string;
+  authorizing_sid: string;
+  authorization_code_session_id: string;
+  email: string;
+  role: string;
+  scopes: string[];
+  client_id: string;
+  redirect_uri: string;
+  code_challenge: string | null;
+  code_challenge_method: string | null;
+  resource: string;
+  exp: number;
 }
 
-function discovery(profile: McpProfile): Record<string, unknown> {
+interface McpAccessTokenClaims extends Omit<AdminSessionTokenClaims, "typ"> {
+  typ: "mcp-access";
+  aud: string;
+  client_id: string;
+}
+
+interface McpRefreshTokenClaims {
+  typ: "mcp-refresh";
+  sub: string;
+  sid: string;
+  email: string;
+  role: string;
+  scopes: string[];
+  aud: string;
+  client_id: string;
+  exp: number;
+}
+
+const MCP_SCOPES = ["mcp:events:read", "mcp:reviews:write"];
+const MCP_ACCESS_TOKEN_TTL_HOURS = 1;
+const MCP_CLIENT_SESSION_TTL_HOURS = 24 * 30;
+const MCP_AUTHORIZATION_CODE_TTL_SECONDS = 300;
+const encoder = new TextEncoder();
+
+function originForRequest(request: Request): string {
+  return new URL(request.url).origin;
+}
+
+function mcpResourceForRequest(request: Request): string {
+  return `${originForRequest(request)}/api/mcp`;
+}
+
+function authorizationServerMetadata(origin: string): Record<string, unknown> {
   return {
-    name: profile === "events" ? "PKI Consortium Events MCP" : "PKI Consortium MCP",
-    profile,
-    transport: "streamable-http",
-    endpoints: {
-      all: "/api/mcp",
-      events: "/api/mcp/events",
-    },
-    capabilities: {
-      tools: true,
-    },
-    tools: toolsForProfile(profile),
+    issuer: origin,
+    authorization_endpoint: `${origin}/api/mcp/oauth/authorize`,
+    token_endpoint: `${origin}/api/mcp/oauth/token`,
+    registration_endpoint: `${origin}/api/mcp/oauth/register`,
+    response_types_supported: ["code"],
+    grant_types_supported: ["authorization_code", "refresh_token"],
+    code_challenge_methods_supported: ["S256", "plain"],
+    token_endpoint_auth_methods_supported: ["none"],
+    scopes_supported: [...MCP_SCOPES, "offline_access"],
   };
+}
+
+function protectedResourceMetadata(origin: string): Record<string, unknown> {
+  return {
+    resource: `${origin}/api/mcp`,
+    authorization_servers: [origin],
+    scopes_supported: MCP_SCOPES,
+    bearer_methods_supported: ["header"],
+  };
+}
+
+export function handleOAuthAuthorizationServerMetadata(request: Request): Response {
+  return jsonNoStore(authorizationServerMetadata(originForRequest(request)));
+}
+
+export function handleOAuthProtectedResourceMetadata(request: Request): Response {
+  return jsonNoStore(protectedResourceMetadata(originForRequest(request)));
 }
 
 function jsonRpcResult(request: JsonRpcRequest, result: unknown): Response {
@@ -119,7 +124,730 @@ function jsonRpcError(request: JsonRpcRequest, code: number, message: string): R
   return jsonNoStore({ jsonrpc: "2.0", id: request.id ?? null, error: { code, message } });
 }
 
-async function handleMcpPost(request: Request, profile: McpProfile): Promise<Response> {
+function jsonRpcToolResult(request: JsonRpcRequest, data: unknown): Response {
+  return jsonRpcResult(request, {
+    content: [
+      {
+        type: "text",
+        text: JSON.stringify(data, null, 2),
+      },
+    ],
+  });
+}
+
+function unauthorizedMcpResponse(request: Request): Response {
+  const origin = originForRequest(request);
+  return jsonNoStore(
+    { error: "authorization_required", error_description: "Authenticate this MCP server from the client /mcp panel." },
+    401,
+    {
+      "WWW-Authenticate": `Bearer resource_metadata="${origin}/.well-known/oauth-protected-resource"`,
+    },
+  );
+}
+
+function parseBearerToken(request: Request): string | null {
+  const auth = request.headers.get("authorization") ?? "";
+  const match = auth.match(/^Bearer\s+(.+)$/i);
+  return match?.[1] ?? null;
+}
+
+function isMcpAccessTokenClaims(claims: object): claims is McpAccessTokenClaims {
+  const candidate = claims as Partial<McpAccessTokenClaims>;
+  return (
+    candidate.typ === "mcp-access" &&
+    typeof candidate.sub === "string" &&
+    typeof candidate.sid === "string" &&
+    typeof candidate.email === "string" &&
+    typeof candidate.role === "string" &&
+    typeof candidate.aud === "string" &&
+    typeof candidate.client_id === "string" &&
+    Array.isArray(candidate.scopes) &&
+    candidate.scopes.every((scope) => typeof scope === "string") &&
+    typeof candidate.exp === "number"
+  );
+}
+
+function isOAuthCodeClaims(claims: object): claims is OAuthCodeClaims {
+  const candidate = claims as Partial<OAuthCodeClaims>;
+  return (
+    candidate.typ === "mcp-oauth-code" &&
+    typeof candidate.sub === "string" &&
+    typeof candidate.authorizing_sid === "string" &&
+    typeof candidate.authorization_code_session_id === "string" &&
+    typeof candidate.email === "string" &&
+    typeof candidate.role === "string" &&
+    Array.isArray(candidate.scopes) &&
+    candidate.scopes.every((scope) => typeof scope === "string") &&
+    typeof candidate.client_id === "string" &&
+    typeof candidate.redirect_uri === "string" &&
+    (candidate.code_challenge === null || typeof candidate.code_challenge === "string") &&
+    (candidate.code_challenge_method === null || typeof candidate.code_challenge_method === "string") &&
+    typeof candidate.resource === "string" &&
+    typeof candidate.exp === "number"
+  );
+}
+
+function isAllowedLoopbackRedirectUri(value: string): boolean {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    return false;
+  }
+
+  if (url.protocol !== "http:") {
+    return false;
+  }
+  if (url.hostname !== "localhost" && url.hostname !== "127.0.0.1" && url.hostname !== "[::1]") {
+    return false;
+  }
+  if (!url.port) {
+    return false;
+  }
+  return url.pathname === "/callback";
+}
+
+function requireLoopbackRedirectUri(value: string): string {
+  if (!isAllowedLoopbackRedirectUri(value)) {
+    throw new AppError(
+      400,
+      "OAUTH_REDIRECT_URI_INVALID",
+      "MCP OAuth redirect_uri must be a loopback callback URL such as http://localhost:12345/callback",
+    );
+  }
+  return value;
+}
+
+function isMcpRefreshTokenClaims(claims: object): claims is McpRefreshTokenClaims {
+  const candidate = claims as Partial<McpRefreshTokenClaims>;
+  return (
+    candidate.typ === "mcp-refresh" &&
+    typeof candidate.sub === "string" &&
+    typeof candidate.sid === "string" &&
+    typeof candidate.email === "string" &&
+    typeof candidate.role === "string" &&
+    typeof candidate.aud === "string" &&
+    typeof candidate.client_id === "string" &&
+    Array.isArray(candidate.scopes) &&
+    candidate.scopes.every((scope) => typeof scope === "string") &&
+    typeof candidate.exp === "number"
+  );
+}
+
+function expFromIso(expiresAt: string): number {
+  const ms = new Date(expiresAt).getTime();
+  if (!Number.isFinite(ms)) {
+    throw new AppError(500, "INVALID_SESSION_EXPIRY", "Unable to issue MCP access token");
+  }
+  return Math.floor(ms / 1000);
+}
+
+function secondsUntil(expiresAt: string): number {
+  return Math.max(0, Math.floor((new Date(expiresAt).getTime() - Date.now()) / 1000));
+}
+
+function accessTokenExpiresAt(sessionExpiresAt: string): string {
+  const requested = new Date(addHours(nowIso(), MCP_ACCESS_TOKEN_TTL_HOURS)).getTime();
+  const sessionExpiry = new Date(sessionExpiresAt).getTime();
+  return new Date(Math.min(requested, sessionExpiry)).toISOString();
+}
+
+async function signMcpAccessToken(
+  env: Env,
+  payload: { admin: AuthAdmin; sessionId: string; sessionExpiresAt: string; clientId: string; resource: string },
+): Promise<{ accessToken: string; expiresAt: string }> {
+  if (!env.INTERNAL_SIGNING_SECRET) {
+    throw new AppError(500, "INTERNAL_SECRET_MISSING", "INTERNAL_SIGNING_SECRET is not configured");
+  }
+
+  const expiresAt = accessTokenExpiresAt(payload.sessionExpiresAt);
+  const accessToken = await signJwt(env.INTERNAL_SIGNING_SECRET, {
+    typ: "mcp-access",
+    sub: payload.admin.id,
+    sid: payload.sessionId,
+    email: payload.admin.email,
+    role: payload.admin.role,
+    scopes: MCP_SCOPES,
+    aud: payload.resource,
+    client_id: payload.clientId,
+    exp: expFromIso(expiresAt),
+  });
+
+  return { accessToken, expiresAt };
+}
+
+async function issueMcpClientSession(
+  env: Env,
+  payload: { admin: AuthAdmin; clientId: string; resource: string },
+): Promise<{
+  accessToken: string;
+  refreshToken: string;
+  sessionId: string;
+  accessTokenExpiresAt: string;
+  refreshTokenExpiresAt: string;
+}> {
+  if (!env.INTERNAL_SIGNING_SECRET) {
+    throw new AppError(500, "INTERNAL_SECRET_MISSING", "INTERNAL_SIGNING_SECRET is not configured");
+  }
+
+  const sessionId = uuid();
+  const now = nowIso();
+  const refreshTokenExpiresAt = addHours(now, MCP_CLIENT_SESSION_TTL_HOURS);
+  const refreshToken = await signJwt(env.INTERNAL_SIGNING_SECRET, {
+    typ: "mcp-refresh",
+    sub: payload.admin.id,
+    sid: sessionId,
+    email: payload.admin.email,
+    role: payload.admin.role,
+    scopes: MCP_SCOPES,
+    aud: payload.resource,
+    client_id: payload.clientId,
+    exp: expFromIso(refreshTokenExpiresAt),
+  });
+  const { accessToken, expiresAt: accessTokenExpiresAt } = await signMcpAccessToken(env, {
+    admin: payload.admin,
+    sessionId,
+    sessionExpiresAt: refreshTokenExpiresAt,
+    clientId: payload.clientId,
+    resource: payload.resource,
+  });
+
+  await run(
+    env.DB,
+    `INSERT INTO sessions (id, user_id, session_type, token_hash, expires_at, revoked_at, created_at)
+     VALUES (?, ?, 'api', ?, ?, NULL, ?)`,
+    [sessionId, payload.admin.id, await sha256Hex(refreshToken), refreshTokenExpiresAt, now],
+  );
+
+  await writeAuditLog(env.DB, "admin", payload.admin.id, "mcp_session_created", "admin_session", sessionId, {
+    clientId: payload.clientId,
+    resource: payload.resource,
+    expiresAt: refreshTokenExpiresAt,
+  });
+
+  return { accessToken, refreshToken, sessionId, accessTokenExpiresAt, refreshTokenExpiresAt };
+}
+
+async function getMcpRefreshActor(env: Env, claims: McpRefreshTokenClaims, refreshToken: string): Promise<AuthAdmin> {
+  const row = await first<{
+    id: string;
+    user_id: string;
+    token_hash: string;
+    expires_at: string;
+    revoked_at: string | null;
+    email: string;
+    role: string;
+  }>(
+    env.DB,
+    `SELECT s.id, s.user_id, s.token_hash, s.expires_at, s.revoked_at, u.email, u.role
+     FROM sessions s
+     JOIN users u ON u.id = s.user_id
+     WHERE s.id = ? AND s.user_id = ? AND s.session_type = 'api' AND u.active = 1 AND u.role = 'admin'`,
+    [claims.sid, claims.sub],
+  );
+
+  if (!row || row.token_hash !== (await sha256Hex(refreshToken))) {
+    throw new AppError(401, "AUTH_INVALID", "Invalid MCP refresh token");
+  }
+  if (row.revoked_at) {
+    throw new AppError(401, "AUTH_REVOKED", "MCP session is revoked");
+  }
+  if (new Date(row.expires_at).getTime() <= Date.now()) {
+    throw new AppError(401, "AUTH_EXPIRED", "MCP session expired");
+  }
+
+  return {
+    id: row.user_id,
+    email: row.email,
+    role: row.role,
+    scopes: claims.scopes,
+    sessionId: row.id,
+    expiresAt: row.expires_at,
+  };
+}
+
+async function requireMcpActor(env: Env, request: Request): Promise<AuthAdmin> {
+  const token = parseBearerToken(request);
+  if (!token) {
+    throw new AppError(401, "AUTH_REQUIRED", "Missing bearer token");
+  }
+  if (!env.INTERNAL_SIGNING_SECRET) {
+    throw new AppError(500, "INTERNAL_SECRET_MISSING", "INTERNAL_SIGNING_SECRET is not configured");
+  }
+
+  const verified = await verifyJwt<object>(env.INTERNAL_SIGNING_SECRET, token);
+  if (!verified.ok) {
+    throw new AppError(
+      401,
+      verified.reason === "expired" ? "AUTH_EXPIRED" : "AUTH_INVALID",
+      "Invalid MCP access token",
+    );
+  }
+  if (!isMcpAccessTokenClaims(verified.claims)) {
+    throw new AppError(401, "AUTH_INVALID", "Invalid MCP access token");
+  }
+  if (verified.claims.aud !== mcpResourceForRequest(request)) {
+    throw new AppError(401, "AUTH_INVALID", "MCP access token audience does not match this server");
+  }
+
+  return getAdminBySessionClaims(env.DB, { ...verified.claims, typ: "admin-session" });
+}
+
+function requireString(args: Record<string, unknown>, name: string): string {
+  const value = args[name];
+  if (typeof value !== "string" || !value.trim()) {
+    throw new AppError(400, "MCP_ARGUMENT_INVALID", `${name} is required`);
+  }
+  return value.trim();
+}
+
+function optionalString(args: Record<string, unknown>, name: string): string | null {
+  const value = args[name];
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function optionalLimit(args: Record<string, unknown>): number {
+  const raw = args.limit;
+  const number = typeof raw === "number" ? raw : Number(raw ?? 50);
+  return Math.min(200, Math.max(1, Number.isFinite(number) ? Math.floor(number) : 50));
+}
+
+function optionalOffset(args: Record<string, unknown>): number {
+  const raw = args.offset;
+  const number = typeof raw === "number" ? raw : Number(raw ?? 0);
+  return Math.max(0, Number.isFinite(number) ? Math.floor(number) : 0);
+}
+
+function requireRecommendation(args: Record<string, unknown>): Recommendation {
+  const value = args.recommendation;
+  if (value === "accept" || value === "reject" || value === "needs-work") {
+    return value;
+  }
+  throw new AppError(400, "MCP_ARGUMENT_INVALID", "recommendation must be accept, reject, or needs-work");
+}
+
+function requireScore(args: Record<string, unknown>): number {
+  const value = args.score;
+  const number = typeof value === "number" ? value : Number(value);
+  if (!Number.isInteger(number) || number < 1 || number > 10) {
+    throw new AppError(400, "MCP_ARGUMENT_INVALID", "score must be an integer from 1 to 10");
+  }
+  return number;
+}
+
+async function requireProposalReviewAccess(env: Env, proposalId: string, actor: AuthAdmin): Promise<ProposalRecord> {
+  const proposal = await first<ProposalRecord>(env.DB, "SELECT * FROM session_proposals WHERE id = ?", [proposalId]);
+  if (!proposal) {
+    throw new AppError(404, "PROPOSAL_NOT_FOUND", "Proposal not found");
+  }
+  const access = await getProposalAccessForEvent(env.DB, proposal.event_id, actor);
+  if (!access.canReview) {
+    throw new AppError(403, "PROPOSAL_ACCESS_DENIED", "You do not have review access to this event");
+  }
+  return proposal;
+}
+
+async function listEvents(env: Env, actor: AuthAdmin): Promise<unknown> {
+  const rows = await all<{
+    id: string;
+    slug: string;
+    name: string;
+    timezone: string;
+    starts_at: string | null;
+    ends_at: string | null;
+    base_path: string | null;
+    permissions: string | null;
+    proposal_count: number;
+  }>(
+    env.DB,
+    `SELECT
+       e.id, e.slug, e.name, e.timezone, e.starts_at, e.ends_at, e.base_path,
+       GROUP_CONCAT(DISTINCT ep.permission) AS permissions,
+       COALESCE(pc.proposal_count, 0) AS proposal_count
+     FROM events e
+     LEFT JOIN event_permissions ep ON ep.event_id = e.id AND (ep.user_id = ? OR ep.user_email = ?)
+     LEFT JOIN (
+       SELECT event_id, COUNT(*) AS proposal_count
+       FROM session_proposals
+       WHERE withdrawn_at IS NULL
+       GROUP BY event_id
+     ) pc ON pc.event_id = e.id
+     WHERE ? = 'admin' OR ep.id IS NOT NULL
+     GROUP BY e.id
+     ORDER BY COALESCE(e.starts_at, '9999') DESC`,
+    [actor.id, actor.email.toLowerCase(), actor.role],
+  );
+
+  return {
+    events: rows.map((row) => ({
+      ...row,
+      permissions: actor.role === "admin" ? ["admin"] : (row.permissions?.split(",").filter(Boolean) ?? []),
+      canReview: actor.role === "admin" || Boolean(row.permissions),
+    })),
+  };
+}
+
+async function listProposals(env: Env, actor: AuthAdmin, args: Record<string, unknown>): Promise<unknown> {
+  const event = await getEventBySlug(env.DB, requireString(args, "eventSlug"));
+  const access = await getProposalAccessForEvent(env.DB, event.id, actor);
+  if (!access.canReview) {
+    throw new AppError(403, "PROPOSAL_ACCESS_DENIED", "You do not have review access to this event");
+  }
+
+  const status = optionalString(args, "status");
+  const reviewStatus = optionalString(args, "reviewStatus") as ReviewStatus | null;
+  const limit = optionalLimit(args);
+  const offset = optionalOffset(args);
+  const conditions = ["sp.event_id = ?"];
+  const params: unknown[] = [event.id];
+
+  if (status) {
+    conditions.push("sp.status = ?");
+    params.push(status);
+  }
+  if (reviewStatus) {
+    if (reviewStatus !== "draft" && reviewStatus !== "submitted") {
+      throw new AppError(400, "MCP_ARGUMENT_INVALID", "reviewStatus must be draft or submitted");
+    }
+    conditions.push("my_review.status = ?");
+    params.push(reviewStatus);
+  }
+
+  const rows = await all<ProposalListRecord & { my_review_status: string | null; my_review_score: number | null }>(
+    env.DB,
+    `SELECT
+       sp.*,
+       u.email AS proposer_email,
+       u.first_name AS proposer_first_name,
+       u.last_name AS proposer_last_name,
+       COALESCE(rv.review_count, 0) AS review_count,
+       pd.final_status AS decision_status,
+       pd.decision_note AS decision_note,
+       pd.decided_at AS decision_decided_at,
+       my_review.status AS my_review_status,
+       my_review.score AS my_review_score
+     FROM session_proposals sp
+     JOIN users u ON u.id = sp.proposer_user_id
+     LEFT JOIN (
+       SELECT proposal_id, COUNT(*) AS review_count
+       FROM proposal_reviews
+       WHERE status = 'submitted'
+       GROUP BY proposal_id
+     ) rv ON rv.proposal_id = sp.id
+     LEFT JOIN proposal_decisions pd ON pd.proposal_id = sp.id
+     LEFT JOIN proposal_reviews my_review ON my_review.proposal_id = sp.id AND my_review.reviewer_user_id = ?
+     WHERE ${conditions.join(" AND ")}
+     ORDER BY sp.submitted_at DESC
+     LIMIT ? OFFSET ?`,
+    [actor.id, ...params, limit + 1, offset],
+  );
+
+  const hasMore = rows.length > limit;
+  const proposals = (hasMore ? rows.slice(0, limit) : rows).map((row) => ({
+    id: row.id,
+    status: row.status,
+    proposalType: row.proposal_type,
+    title: row.title,
+    submittedAt: row.submitted_at,
+    proposer: {
+      email: row.proposer_email,
+      firstName: row.proposer_first_name,
+      lastName: row.proposer_last_name,
+    },
+    submittedReviewCount: row.review_count,
+    myReview: row.my_review_status
+      ? {
+          status: row.my_review_status,
+          score: row.my_review_score,
+        }
+      : null,
+    decisionStatus: row.decision_status,
+  }));
+
+  return { event: { id: event.id, slug: event.slug, name: event.name }, proposals, page: { limit, offset, hasMore } };
+}
+
+async function readProposal(env: Env, actor: AuthAdmin, args: Record<string, unknown>): Promise<unknown> {
+  const proposal = await requireProposalReviewAccess(env, requireString(args, "proposalId"), actor);
+  const proposer = await first<{ email: string; first_name: string | null; last_name: string | null }>(
+    env.DB,
+    "SELECT email, first_name, last_name FROM users WHERE id = ?",
+    [proposal.proposer_user_id],
+  );
+  const reviews = await listProposalReviews(env.DB, proposal.id);
+  return {
+    proposal: {
+      id: proposal.id,
+      eventId: proposal.event_id,
+      status: proposal.status,
+      proposalType: proposal.proposal_type,
+      title: proposal.title,
+      abstract: proposal.abstract,
+      details: proposal.details_json ? JSON.parse(proposal.details_json) : null,
+      submittedAt: proposal.submitted_at,
+      proposer,
+    },
+    reviews: reviews.map((review) => ({
+      id: review.id,
+      reviewerEmail: review.reviewer_email,
+      recommendation: review.recommendation,
+      status: review.status,
+      score: review.score,
+      reviewerComment: review.reviewer_comment,
+      applicantNote: review.applicant_note,
+      submittedAt: review.submitted_at,
+      updatedAt: review.updated_at,
+    })),
+  };
+}
+
+async function getMine(env: Env, actor: AuthAdmin, args: Record<string, unknown>): Promise<unknown> {
+  const proposal = await requireProposalReviewAccess(env, requireString(args, "proposalId"), actor);
+  const review = await first<ProposalReviewRecord>(
+    env.DB,
+    "SELECT * FROM proposal_reviews WHERE proposal_id = ? AND reviewer_user_id = ?",
+    [proposal.id, actor.id],
+  );
+  return { proposalId: proposal.id, review };
+}
+
+async function saveReview(
+  env: Env,
+  actor: AuthAdmin,
+  args: Record<string, unknown>,
+  status: ReviewStatus,
+): Promise<unknown> {
+  const proposal = await requireProposalReviewAccess(env, requireString(args, "proposalId"), actor);
+  const before = await first<ProposalReviewRecord>(
+    env.DB,
+    "SELECT * FROM proposal_reviews WHERE proposal_id = ? AND reviewer_user_id = ?",
+    [proposal.id, actor.id],
+  );
+  const review = await upsertProposalReview(env.DB, {
+    proposalId: proposal.id,
+    reviewerUserId: actor.id,
+    recommendation: requireRecommendation(args),
+    score: requireScore(args),
+    reviewerComment: optionalString(args, "reviewerComment"),
+    applicantNote: optionalString(args, "applicantNote"),
+    status,
+  });
+  const changes = buildProposalReviewAuditDetails(
+    {
+      recommendation: before?.recommendation ?? null,
+      status: before?.status ?? null,
+      score: before?.score ?? null,
+      reviewerComment: before?.reviewer_comment ?? null,
+      applicantNote: before?.applicant_note ?? null,
+    },
+    {
+      recommendation: review.recommendation,
+      status: review.status,
+      score: review.score,
+      reviewerComment: review.reviewer_comment,
+      applicantNote: review.applicant_note,
+    },
+  );
+  await writeAuditLog(env.DB, "admin", actor.id, "proposal_review_upserted_mcp", "proposal_review", review.id, {
+    proposalId: proposal.id,
+    changes,
+  });
+  return { proposalId: proposal.id, review };
+}
+
+async function callTool(env: Env, request: Request, body: JsonRpcRequest): Promise<Response> {
+  const params = body.params as McpToolCallParams;
+  if (!params || typeof params.name !== "string") {
+    return jsonRpcError(body, -32602, "tools/call requires a tool name");
+  }
+
+  const actor = await requireMcpActor(env, request);
+  const args = params.arguments && typeof params.arguments === "object" ? params.arguments : {};
+  switch (params.name) {
+    case "events_list":
+      return jsonRpcToolResult(body, await listEvents(env, actor));
+    case "events_proposals_list":
+      return jsonRpcToolResult(body, await listProposals(env, actor, args));
+    case "events_proposals_read":
+      return jsonRpcToolResult(body, await readProposal(env, actor, args));
+    case "events_reviews_get_mine":
+      return jsonRpcToolResult(body, await getMine(env, actor, args));
+    case "events_reviews_save_draft":
+      return jsonRpcToolResult(body, await saveReview(env, actor, args, "draft"));
+    case "events_reviews_submit":
+      return jsonRpcToolResult(body, await saveReview(env, actor, args, "submitted"));
+    default:
+      return jsonRpcError(body, -32601, `Unknown tool: ${params.name}`);
+  }
+}
+
+function b64url(bytes: Uint8Array): string {
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
+}
+
+async function sha256B64Url(input: string): Promise<string> {
+  return b64url(new Uint8Array(await crypto.subtle.digest("SHA-256", encoder.encode(input))));
+}
+
+function adminAuthorizeUrl(request: Request): string {
+  const url = new URL(request.url);
+  const encoded = btoa(JSON.stringify(Object.fromEntries(url.searchParams.entries())));
+  return `${originForRequest(request)}/admin/?mcp_authorize=${encodeURIComponent(encoded)}`;
+}
+
+async function handleAuthorizeApprove(c: { env: Env; req: { raw: Request } }): Promise<Response> {
+  const body = (await c.req.raw.json().catch(() => ({}))) as Record<string, unknown>;
+  const clientId = requireString(body, "client_id");
+  const redirectUri = requireLoopbackRedirectUri(requireString(body, "redirect_uri"));
+  const responseType = requireString(body, "response_type");
+  if (responseType !== "code") {
+    throw new AppError(400, "OAUTH_RESPONSE_TYPE_UNSUPPORTED", "Only authorization code flow is supported");
+  }
+  const codeChallenge = optionalString(body, "code_challenge");
+  const codeChallengeMethod = optionalString(body, "code_challenge_method") ?? (codeChallenge ? "plain" : null);
+  if (codeChallengeMethod && codeChallengeMethod !== "plain" && codeChallengeMethod !== "S256") {
+    throw new AppError(400, "OAUTH_PKCE_UNSUPPORTED", "Only plain and S256 PKCE methods are supported");
+  }
+
+  const admin = await requireAdminFromRequest(c.env.DB, c.req.raw, c.env);
+  if (!admin.sessionId || !admin.expiresAt) {
+    throw new AppError(401, "AUTH_REQUIRED", "An interactive admin session is required");
+  }
+  if (!c.env.INTERNAL_SIGNING_SECRET) {
+    throw new AppError(500, "INTERNAL_SECRET_MISSING", "INTERNAL_SIGNING_SECRET is not configured");
+  }
+
+  const codeSessionId = uuid();
+  const codeExpiresAt = new Date(Date.now() + MCP_AUTHORIZATION_CODE_TTL_SECONDS * 1000).toISOString();
+  const code = await signJwt(c.env.INTERNAL_SIGNING_SECRET, {
+    typ: "mcp-oauth-code",
+    sub: admin.id,
+    authorizing_sid: admin.sessionId,
+    authorization_code_session_id: codeSessionId,
+    email: admin.email,
+    role: admin.role,
+    scopes: MCP_SCOPES,
+    client_id: clientId,
+    redirect_uri: redirectUri,
+    code_challenge: codeChallenge,
+    code_challenge_method: codeChallengeMethod,
+    resource: `${originForRequest(c.req.raw)}/api/mcp`,
+    exp: Math.floor(Date.now() / 1000) + MCP_AUTHORIZATION_CODE_TTL_SECONDS,
+  });
+
+  await run(
+    c.env.DB,
+    `INSERT INTO sessions (id, user_id, session_type, token_hash, expires_at, revoked_at, created_at)
+     VALUES (?, ?, 'api', ?, ?, NULL, ?)`,
+    [codeSessionId, admin.id, await sha256Hex(code), codeExpiresAt, nowIso()],
+  );
+
+  const redirect = new URL(redirectUri);
+  redirect.searchParams.set("code", code);
+  const state = optionalString(body, "state");
+  if (state) redirect.searchParams.set("state", state);
+  return jsonNoStore({ redirectTo: redirect.toString() });
+}
+
+async function handleToken(c: { env: Env; req: { raw: Request } }): Promise<Response> {
+  if (!c.env.INTERNAL_SIGNING_SECRET) {
+    throw new AppError(500, "INTERNAL_SECRET_MISSING", "INTERNAL_SIGNING_SECRET is not configured");
+  }
+  const form = await c.req.raw.formData();
+  const grantType = String(form.get("grant_type") ?? "");
+  if (grantType === "refresh_token") {
+    const refreshToken = String(form.get("refresh_token") ?? "");
+    const clientId = String(form.get("client_id") ?? "");
+    const verified = await verifyJwt<object>(c.env.INTERNAL_SIGNING_SECRET, refreshToken);
+    if (!verified.ok || !isMcpRefreshTokenClaims(verified.claims) || verified.claims.client_id !== clientId) {
+      return jsonNoStore({ error: "invalid_grant" }, 400);
+    }
+    const admin = await getMcpRefreshActor(c.env, verified.claims, refreshToken);
+    const { accessToken, expiresAt } = await signMcpAccessToken(c.env, {
+      admin,
+      sessionId: verified.claims.sid,
+      sessionExpiresAt: admin.expiresAt ?? nowIso(),
+      clientId,
+      resource: verified.claims.aud,
+    });
+
+    return jsonNoStore({
+      access_token: accessToken,
+      token_type: "Bearer",
+      expires_in: secondsUntil(expiresAt),
+      scope: MCP_SCOPES.join(" "),
+    });
+  }
+
+  if (grantType !== "authorization_code") {
+    return jsonNoStore({ error: "unsupported_grant_type" }, 400);
+  }
+  const code = String(form.get("code") ?? "");
+  const clientId = String(form.get("client_id") ?? "");
+  const redirectUri = requireLoopbackRedirectUri(String(form.get("redirect_uri") ?? ""));
+  const codeVerifier = form.get("code_verifier") ? String(form.get("code_verifier")) : null;
+  const verified = await verifyJwt<object>(c.env.INTERNAL_SIGNING_SECRET, code);
+  if (!verified.ok || !isOAuthCodeClaims(verified.claims)) {
+    return jsonNoStore({ error: "invalid_grant" }, 400);
+  }
+  if (verified.claims.client_id !== clientId || verified.claims.redirect_uri !== redirectUri) {
+    return jsonNoStore({ error: "invalid_grant" }, 400);
+  }
+
+  const consume = await run(
+    c.env.DB,
+    `UPDATE sessions
+     SET revoked_at = ?
+     WHERE id = ?
+       AND user_id = ?
+       AND session_type = 'api'
+       AND token_hash = ?
+       AND revoked_at IS NULL
+       AND expires_at > ?`,
+    [nowIso(), verified.claims.authorization_code_session_id, verified.claims.sub, await sha256Hex(code), nowIso()],
+  );
+  if (consume.changes === 0) {
+    return jsonNoStore({ error: "invalid_grant" }, 400);
+  }
+
+  if (verified.claims.code_challenge) {
+    if (!codeVerifier) {
+      return jsonNoStore({ error: "invalid_request", error_description: "Missing code_verifier" }, 400);
+    }
+    const expected = verified.claims.code_challenge_method === "S256" ? await sha256B64Url(codeVerifier) : codeVerifier;
+    if (expected !== verified.claims.code_challenge) {
+      return jsonNoStore({ error: "invalid_grant" }, 400);
+    }
+  }
+
+  const admin = await getAdminBySessionClaims(c.env.DB, {
+    typ: "admin-session",
+    sub: verified.claims.sub,
+    sid: verified.claims.authorizing_sid,
+    email: verified.claims.email,
+    role: verified.claims.role,
+    scopes: verified.claims.scopes,
+    exp: verified.claims.exp,
+  });
+  const { accessToken, refreshToken, accessTokenExpiresAt } = await issueMcpClientSession(c.env, {
+    admin,
+    clientId,
+    resource: verified.claims.resource,
+  });
+
+  return jsonNoStore({
+    access_token: accessToken,
+    refresh_token: refreshToken,
+    token_type: "Bearer",
+    expires_in: secondsUntil(accessTokenExpiresAt),
+    scope: MCP_SCOPES.join(" "),
+  });
+}
+
+async function handleMcpPost(request: Request, env: Env, profile: McpProfile): Promise<Response> {
   const body = (await request.json().catch(() => null)) as JsonRpcRequest | null;
   if (!body || body.jsonrpc !== "2.0" || typeof body.method !== "string") {
     return jsonRpcError({ id: null }, -32600, "Invalid JSON-RPC request");
@@ -141,17 +869,75 @@ async function handleMcpPost(request: Request, profile: McpProfile): Promise<Res
   }
 
   if (body.method === "tools/call") {
-    return jsonRpcError(body, -32601, "MCP tool execution is not implemented yet");
+    try {
+      return await callTool(env, request, body);
+    } catch (error) {
+      if (isAppError(error) && (error.status === 401 || error.status === 403)) {
+        return unauthorizedMcpResponse(request);
+      }
+      if (isAppError(error)) {
+        return jsonRpcError(body, -32602, error.message);
+      }
+      return jsonRpcError(body, -32603, error instanceof Error ? error.message : "Internal error");
+    }
   }
 
   return jsonRpcError(body, -32601, "Method not found");
 }
 
-const app = new Hono();
+const app = new Hono<{ Bindings: Env }>();
 
 app.get("/", () => jsonNoStore(discovery("all")));
-app.post("/", (c) => handleMcpPost(c.req.raw, "all"));
+app.post("/", (c) => handleMcpPost(c.req.raw, c.env, "all"));
 app.get("/events", () => jsonNoStore(discovery("events")));
-app.post("/events", (c) => handleMcpPost(c.req.raw, "events"));
+app.post("/events", (c) => handleMcpPost(c.req.raw, c.env, "events"));
+app.post("/oauth/register", async (c) => {
+  const body = (await c.req.raw.json().catch(() => ({}))) as Record<string, unknown>;
+  const redirectUris = Array.isArray(body.redirect_uris)
+    ? body.redirect_uris.filter((value): value is string => typeof value === "string")
+    : [];
+  if (redirectUris.some((redirectUri) => !isAllowedLoopbackRedirectUri(redirectUri))) {
+    return jsonNoStore(
+      {
+        error: "invalid_redirect_uri",
+        error_description: "redirect_uris must be loopback callback URLs such as http://localhost:12345/callback",
+      },
+      400,
+    );
+  }
+  const clientId = `pkic-mcp-${crypto.randomUUID()}`;
+  return jsonNoStore(
+    {
+      client_id: clientId,
+      client_id_issued_at: Math.floor(Date.now() / 1000),
+      redirect_uris: redirectUris,
+      grant_types: ["authorization_code"],
+      response_types: ["code"],
+      token_endpoint_auth_method: "none",
+    },
+    201,
+  );
+});
+app.get("/oauth/authorize", (c) => Response.redirect(adminAuthorizeUrl(c.req.raw), 302));
+app.post("/oauth/authorize/approve", async (c) => {
+  try {
+    return await handleAuthorizeApprove(c);
+  } catch (error) {
+    if (isAppError(error)) {
+      return jsonNoStore({ error: error.code, error_description: error.message }, error.status);
+    }
+    return jsonNoStore({ error: "server_error" }, 500);
+  }
+});
+app.post("/oauth/token", async (c) => {
+  try {
+    return await handleToken(c);
+  } catch (error) {
+    if (isAppError(error)) {
+      return jsonNoStore({ error: error.code, error_description: error.message }, error.status);
+    }
+    return jsonNoStore({ error: "server_error" }, 500);
+  }
+});
 
 export default app;

--- a/functions/api/mcp/tools.ts
+++ b/functions/api/mcp/tools.ts
@@ -1,0 +1,103 @@
+import type { McpProfile } from "./router";
+
+interface McpToolDefinition {
+  name: string;
+  description: string;
+  inputSchema: {
+    type: "object";
+    properties: Record<string, unknown>;
+    required?: string[];
+  };
+}
+
+const eventTools: McpToolDefinition[] = [
+  {
+    name: "events_list",
+    description: "List events the authenticated user can access.",
+    inputSchema: { type: "object", properties: {} },
+  },
+  {
+    name: "events_proposals_list",
+    description: "List event proposals visible to the authenticated reviewer.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        eventSlug: { type: "string" },
+        status: { type: "string" },
+        reviewStatus: { type: "string", enum: ["draft", "submitted"] },
+      },
+      required: ["eventSlug"],
+    },
+  },
+  {
+    name: "events_proposals_read",
+    description: "Read one proposal, including abstract and review metadata.",
+    inputSchema: {
+      type: "object",
+      properties: { proposalId: { type: "string" } },
+      required: ["proposalId"],
+    },
+  },
+  {
+    name: "events_reviews_get_mine",
+    description: "Read the authenticated user's review or draft for a proposal.",
+    inputSchema: {
+      type: "object",
+      properties: { proposalId: { type: "string" } },
+      required: ["proposalId"],
+    },
+  },
+  {
+    name: "events_reviews_save_draft",
+    description: "Save a complete draft review for the authenticated reviewer.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        proposalId: { type: "string" },
+        recommendation: { type: "string", enum: ["accept", "reject", "needs-work"] },
+        score: { type: "integer", minimum: 1, maximum: 10 },
+        reviewerComment: { type: "string" },
+        applicantNote: { type: "string" },
+      },
+      required: ["proposalId", "recommendation", "score"],
+    },
+  },
+  {
+    name: "events_reviews_submit",
+    description: "Submit a complete review as the authenticated reviewer.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        proposalId: { type: "string" },
+        recommendation: { type: "string", enum: ["accept", "reject", "needs-work"] },
+        score: { type: "integer", minimum: 1, maximum: 10 },
+        reviewerComment: { type: "string" },
+        applicantNote: { type: "string" },
+      },
+      required: ["proposalId", "recommendation", "score"],
+    },
+  },
+];
+
+export function toolsForProfile(profile: McpProfile): McpToolDefinition[] {
+  if (profile === "events") {
+    return eventTools;
+  }
+  return eventTools;
+}
+
+export function discovery(profile: McpProfile): Record<string, unknown> {
+  return {
+    name: profile === "events" ? "PKI Consortium Events MCP" : "PKI Consortium MCP",
+    profile,
+    transport: "streamable-http",
+    endpoints: {
+      all: "/api/mcp",
+      events: "/api/mcp/events",
+    },
+    capabilities: {
+      tools: true,
+    },
+    tools: toolsForProfile(profile),
+  };
+}

--- a/functions/api/router.ts
+++ b/functions/api/router.ts
@@ -1,10 +1,12 @@
 import { Hono } from "hono";
 import { fromHono } from "chanfana";
+import mcp_Router from "./mcp/router";
 import v1_Router from "./v1/router";
 
 const app = new Hono();
 export const openapi = fromHono(app);
 
+app.route("/mcp", mcp_Router);
 app.route("/v1", v1_Router);
 
 export default app;

--- a/functions/api/v1/admin/events/[eventSlug]/proposals.ts
+++ b/functions/api/v1/admin/events/[eventSlug]/proposals.ts
@@ -49,6 +49,7 @@ export async function onRequestGet(c: AdminContext): Promise<Response> {
      LEFT JOIN (
        SELECT proposal_id, COUNT(*) AS review_count
        FROM proposal_reviews
+       WHERE status = 'submitted'
        GROUP BY proposal_id
      ) rv ON rv.proposal_id = sp.id
      LEFT JOIN proposal_decisions pd ON pd.proposal_id = sp.id

--- a/functions/api/v1/admin/proposals/[proposalId]/index.ts
+++ b/functions/api/v1/admin/proposals/[proposalId]/index.ts
@@ -34,6 +34,7 @@ export async function onRequestGet(c: AdminContext): Promise<Response> {
      LEFT JOIN (
        SELECT proposal_id, COUNT(*) AS review_count
        FROM proposal_reviews
+       WHERE status = 'submitted'
        GROUP BY proposal_id
      ) rv ON rv.proposal_id = sp.id
      LEFT JOIN proposal_decisions pd ON pd.proposal_id = sp.id

--- a/functions/api/v1/admin/proposals/[proposalId]/reviews.ts
+++ b/functions/api/v1/admin/proposals/[proposalId]/reviews.ts
@@ -54,12 +54,13 @@ export async function onRequestPost(c: AdminContext): Promise<Response> {
   const existing = await first<{
     id: string;
     recommendation: string;
+    status: string;
     score: number | null;
     reviewer_comment: string | null;
     applicant_note: string | null;
   }>(
     requestDb(c),
-    `SELECT id, recommendation, score, reviewer_comment, applicant_note
+    `SELECT id, recommendation, status, score, reviewer_comment, applicant_note
      FROM proposal_reviews
      WHERE proposal_id = ? AND reviewer_user_id = ?`,
     [proposalId, admin.id],
@@ -69,6 +70,7 @@ export async function onRequestPost(c: AdminContext): Promise<Response> {
     proposalId,
     reviewerUserId: admin.id,
     recommendation: body.recommendation,
+    status: body.status,
     score: body.score,
     reviewerComment: body.reviewerComment,
     applicantNote: body.applicantNote,
@@ -76,12 +78,14 @@ export async function onRequestPost(c: AdminContext): Promise<Response> {
 
   const before = {
     recommendation: existing?.recommendation ?? null,
+    status: existing?.status ?? null,
     score: existing?.score ?? null,
     reviewerComment: existing?.reviewer_comment ?? null,
     applicantNote: existing?.applicant_note ?? null,
   };
   const after = {
     recommendation: review.recommendation,
+    status: review.status,
     score: review.score,
     reviewerComment: review.reviewer_comment ?? null,
     applicantNote: review.applicant_note ?? null,

--- a/functions/api/v1/admin/proposals/[proposalId]/reviews/[reviewId].ts
+++ b/functions/api/v1/admin/proposals/[proposalId]/reviews/[reviewId].ts
@@ -40,12 +40,13 @@ export async function onRequestPatch(c: AdminContext): Promise<Response> {
 
   const existing = await first<{
     recommendation: string;
+    status: string;
     score: number | null;
     reviewer_comment: string | null;
     applicant_note: string | null;
   }>(
     requestDb(c),
-    `SELECT recommendation, score, reviewer_comment, applicant_note
+    `SELECT recommendation, status, score, reviewer_comment, applicant_note
      FROM proposal_reviews
      WHERE id = ?`,
     [reviewId],
@@ -57,12 +58,14 @@ export async function onRequestPatch(c: AdminContext): Promise<Response> {
     const changes = buildProposalReviewAuditDetails(
       {
         recommendation: existing.recommendation,
+        status: existing.status,
         score: existing.score,
         reviewerComment: existing.reviewer_comment ?? null,
         applicantNote: existing.applicant_note ?? null,
       },
       {
         recommendation: review.recommendation,
+        status: review.status,
         score: review.score,
         reviewerComment: review.reviewer_comment ?? null,
         applicantNote: review.applicant_note ?? null,

--- a/functions/router.ts
+++ b/functions/router.ts
@@ -4,6 +4,7 @@ import { logError, logInfo } from "./_lib/logging";
 import { runRetentionJob } from "./_lib/services/retention";
 import { runScheduledDueWork } from "./_lib/services/scheduled-due-work";
 import api_Router from "./api/router";
+import { handleOAuthAuthorizationServerMetadata, handleOAuthProtectedResourceMetadata } from "./api/mcp/router";
 import donate_Router from "./donate/router";
 import r_Router from "./r/router";
 import { onRequestGet as OgCardGet } from "./api/v1/og/card/[...path]";
@@ -17,6 +18,9 @@ const REMINDER_CRON = "*/15 * * * *";
 const RETENTION_CRON = "0 3 * * *";
 
 app.get("/og/*", OgCardGet);
+app.get("/.well-known/oauth-protected-resource", (c) => handleOAuthProtectedResourceMetadata(c.req.raw));
+app.get("/.well-known/oauth-protected-resource/*", (c) => handleOAuthProtectedResourceMetadata(c.req.raw));
+app.get("/.well-known/oauth-authorization-server", (c) => handleOAuthAuthorizationServerMetadata(c.req.raw));
 app.route("/api", api_Router);
 app.route("/donate", donate_Router);
 app.route("/r", r_Router);

--- a/migrations/0026_proposal_review_status.sql
+++ b/migrations/0026_proposal_review_status.sql
@@ -1,0 +1,8 @@
+ALTER TABLE proposal_reviews ADD COLUMN status TEXT NOT NULL DEFAULT 'submitted';
+ALTER TABLE proposal_reviews ADD COLUMN submitted_at TEXT;
+
+UPDATE proposal_reviews
+SET submitted_at = COALESCE(updated_at, created_at)
+WHERE status = 'submitted';
+
+CREATE INDEX idx_proposal_reviews_proposal_status ON proposal_reviews(proposal_id, status);

--- a/package.json
+++ b/package.json
@@ -73,6 +73,12 @@
     "wrangler": "^4.93.0"
   },
   "pnpm": {
+    "overrides": {
+      "basic-ftp": ">=5.3.1",
+      "brace-expansion": ">=5.0.6",
+      "ip-address": ">=10.1.1",
+      "ws": ">=8.20.1"
+    },
     "onlyBuiltDependencies": [
       "better-sqlite3",
       "sharp"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,12 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  basic-ftp: '>=5.3.1'
+  brace-expansion: '>=5.0.6'
+  ip-address: '>=10.1.1'
+  ws: '>=8.20.1'
+
 importers:
 
   .:
@@ -50,7 +56,7 @@ importers:
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: ^1.32.3
-        version: 1.32.3(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.7)(yaml@2.8.3))(workerd@1.20260317.1)(wrangler@4.93.0(@cloudflare/workers-types@4.20260416.2))
+        version: 1.32.3(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.7)(yaml@2.8.3))(workerd@1.20260518.1)(wrangler@4.93.0(@cloudflare/workers-types@4.20260416.2))
       '@cloudflare/vitest-pool-workers':
         specifier: ^0.13.5
         version: 0.13.5(@cloudflare/workers-types@4.20260416.2)(@vitest/runner@4.1.4)(@vitest/snapshot@4.1.4)(vitest@4.1.4(@types/node@24.12.2)(jsdom@27.4.0)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.7)(yaml@2.8.3)))
@@ -1240,8 +1246,8 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
-  basic-ftp@5.3.0:
-    resolution: {integrity: sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w==}
+  basic-ftp@6.0.1:
+    resolution: {integrity: sha512-3ilxa3n4276wGQp/ImRAuz4ALdsj/2Wd3FqoZBZlajDYnByCZ0JMb4+26Rde0wGXIbM0G2HWSfr/Fi8b21KX8g==}
     engines: {node: '>=10.0.0'}
 
   bidi-js@1.0.3:
@@ -1250,8 +1256,8 @@ packages:
   blake3-wasm@2.1.5:
     resolution: {integrity: sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==}
 
-  brace-expansion@5.0.5:
-    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
     engines: {node: 18 || 20 || >=22}
 
   buffer-crc32@0.2.13:
@@ -1564,8 +1570,8 @@ packages:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
 
-  ip-address@10.1.0:
-    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
+  ip-address@10.2.0:
+    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
     engines: {node: '>= 12'}
 
   is-extglob@2.1.1:
@@ -2231,20 +2237,8 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
-  ws@8.18.0:
-    resolution: {integrity: sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: '>=5.0.2'
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-
-  ws@8.20.0:
-    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -2338,7 +2332,7 @@ snapshots:
       '@puppeteer/browsers': 2.2.4
       debug: 4.4.3
       devtools-protocol: 0.0.1299070
-      ws: 8.20.0
+      ws: 8.21.0
     transitivePeerDependencies:
       - bare-abort-controller
       - bare-buffer
@@ -2353,20 +2347,26 @@ snapshots:
     optionalDependencies:
       workerd: 1.20260317.1
 
+  '@cloudflare/unenv-preset@2.16.0(unenv@2.0.0-rc.24)(workerd@1.20260518.1)':
+    dependencies:
+      unenv: 2.0.0-rc.24
+    optionalDependencies:
+      workerd: 1.20260518.1
+
   '@cloudflare/unenv-preset@2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260518.1)':
     dependencies:
       unenv: 2.0.0-rc.24
     optionalDependencies:
       workerd: 1.20260518.1
 
-  '@cloudflare/vite-plugin@1.32.3(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.7)(yaml@2.8.3))(workerd@1.20260317.1)(wrangler@4.93.0(@cloudflare/workers-types@4.20260416.2))':
+  '@cloudflare/vite-plugin@1.32.3(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.7)(yaml@2.8.3))(workerd@1.20260518.1)(wrangler@4.93.0(@cloudflare/workers-types@4.20260416.2))':
     dependencies:
-      '@cloudflare/unenv-preset': 2.16.0(unenv@2.0.0-rc.24)(workerd@1.20260317.1)
+      '@cloudflare/unenv-preset': 2.16.0(unenv@2.0.0-rc.24)(workerd@1.20260518.1)
       miniflare: 4.20260415.0
       unenv: 2.0.0-rc.24
       vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.7)(yaml@2.8.3)
       wrangler: 4.93.0(@cloudflare/workers-types@4.20260416.2)
-      ws: 8.18.0
+      ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -3149,7 +3149,7 @@ snapshots:
 
   base64-js@1.5.1: {}
 
-  basic-ftp@5.3.0: {}
+  basic-ftp@6.0.1: {}
 
   bidi-js@1.0.3:
     dependencies:
@@ -3157,7 +3157,7 @@ snapshots:
 
   blake3-wasm@2.1.5: {}
 
-  brace-expansion@5.0.5:
+  brace-expansion@5.0.6:
     dependencies:
       balanced-match: 4.0.4
 
@@ -3471,7 +3471,7 @@ snapshots:
 
   get-uri@6.0.5:
     dependencies:
-      basic-ftp: 5.3.0
+      basic-ftp: 6.0.1
       data-uri-to-buffer: 6.0.2
       debug: 4.4.3
     transitivePeerDependencies:
@@ -3522,7 +3522,7 @@ snapshots:
 
   imurmurhash@0.1.4: {}
 
-  ip-address@10.1.0: {}
+  ip-address@10.2.0: {}
 
   is-extglob@2.1.1: {}
 
@@ -3560,7 +3560,7 @@ snapshots:
       webidl-conversions: 8.0.1
       whatwg-mimetype: 4.0.0
       whatwg-url: 15.1.0
-      ws: 8.20.0
+      ws: 8.21.0
       xml-name-validator: 5.0.0
     transitivePeerDependencies:
       - '@noble/hashes'
@@ -3656,7 +3656,7 @@ snapshots:
       sharp: 0.34.5
       undici: 7.24.4
       workerd: 1.20260317.1
-      ws: 8.18.0
+      ws: 8.21.0
       youch: 4.1.0-beta.10
     transitivePeerDependencies:
       - bufferutil
@@ -3668,7 +3668,7 @@ snapshots:
       sharp: 0.34.5
       undici: 7.24.8
       workerd: 1.20260415.1
-      ws: 8.18.0
+      ws: 8.21.0
       youch: 4.1.0-beta.10
     transitivePeerDependencies:
       - bufferutil
@@ -3680,7 +3680,7 @@ snapshots:
       sharp: 0.34.5
       undici: 7.24.8
       workerd: 1.20260518.1
-      ws: 8.18.0
+      ws: 8.21.0
       youch: 4.1.0-beta.10
     transitivePeerDependencies:
       - bufferutil
@@ -3688,7 +3688,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.5
+      brace-expansion: 5.0.6
 
   minimist@1.2.8: {}
 
@@ -3913,7 +3913,7 @@ snapshots:
 
   socks@2.8.7:
     dependencies:
-      ip-address: 10.1.0
+      ip-address: 10.2.0
       smart-buffer: 4.2.0
 
   source-map-js@1.2.1: {}
@@ -4205,9 +4205,7 @@ snapshots:
 
   wrappy@1.0.2: {}
 
-  ws@8.18.0: {}
-
-  ws@8.20.0: {}
+  ws@8.21.0: {}
 
   xml-name-validator@5.0.0: {}
 

--- a/tests/proposal-review.test.ts
+++ b/tests/proposal-review.test.ts
@@ -225,4 +225,111 @@ describe("proposal review and finalize", () => {
     ]);
     expect(status[0].status).toBe("accepted");
   });
+
+  it("does not count draft reviews toward final decision threshold", async () => {
+    const { eventId } = await seedEventAndAdmin(env.DB);
+    const { proposalId, admin1Id, admin2Id } = await seedProposal(env.DB, eventId);
+
+    const admin1Token = await createAdminSession(env.DB, admin1Id, "token-admin-1");
+    const admin2Token = await createAdminSession(env.DB, admin2Id, "token-admin-2");
+
+    await upsertReview(
+      createContext(
+        env,
+        new Request(`https://app.test/api/v1/admin/proposals/${proposalId}/reviews`, {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            authorization: `Bearer ${admin1Token}`,
+          },
+          body: JSON.stringify({ recommendation: "accept", score: 9, reviewerComment: "Good", status: "draft" }),
+        }),
+        { proposalId },
+      ),
+    );
+
+    const draftRows = await queryAll<{ status: string; submitted_at: string | null }>(
+      env.DB,
+      "SELECT status, submitted_at FROM proposal_reviews WHERE proposal_id = ? AND reviewer_user_id = ?",
+      [proposalId, admin1Id],
+    );
+    expect(draftRows).toEqual([{ status: "draft", submitted_at: null }]);
+
+    await expect(
+      finalizeProposal(
+        createContext(
+          env,
+          new Request(`https://app.test/api/v1/admin/proposals/${proposalId}/finalize`, {
+            method: "POST",
+            headers: {
+              "content-type": "application/json",
+              authorization: `Bearer ${admin1Token}`,
+            },
+            body: JSON.stringify({ finalStatus: "accepted", minReviewsRequired: 1 }),
+          }),
+          { proposalId },
+        ),
+      ),
+    ).rejects.toMatchObject({ code: "PROPOSAL_REVIEW_THRESHOLD_NOT_MET" });
+
+    await upsertReview(
+      createContext(
+        env,
+        new Request(`https://app.test/api/v1/admin/proposals/${proposalId}/reviews`, {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            authorization: `Bearer ${admin1Token}`,
+          },
+          body: JSON.stringify({ recommendation: "accept", score: 9, reviewerComment: "Good", status: "submitted" }),
+        }),
+        { proposalId },
+      ),
+    );
+
+    await upsertReview(
+      createContext(
+        env,
+        new Request(`https://app.test/api/v1/admin/proposals/${proposalId}/reviews`, {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            authorization: `Bearer ${admin2Token}`,
+          },
+          body: JSON.stringify({
+            recommendation: "accept",
+            score: 8,
+            reviewerComment: "Also good",
+            status: "submitted",
+          }),
+        }),
+        { proposalId },
+      ),
+    );
+
+    const submittedRows = await queryAll<{ status: string; submitted_at: string | null }>(
+      env.DB,
+      "SELECT status, submitted_at FROM proposal_reviews WHERE proposal_id = ? AND reviewer_user_id = ?",
+      [proposalId, admin1Id],
+    );
+    expect(submittedRows[0].status).toBe("submitted");
+    expect(submittedRows[0].submitted_at).toBeTruthy();
+
+    const finalizeResponse = await finalizeProposal(
+      createContext(
+        env,
+        new Request(`https://app.test/api/v1/admin/proposals/${proposalId}/finalize`, {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            authorization: `Bearer ${admin1Token}`,
+          },
+          body: JSON.stringify({ finalStatus: "accepted", minReviewsRequired: 1 }),
+        }),
+        { proposalId },
+      ),
+    );
+
+    expect(finalizeResponse.status).toBe(200);
+  });
 });

--- a/tests/proposal-review.test.ts
+++ b/tests/proposal-review.test.ts
@@ -162,11 +162,7 @@ describe("proposal review and finalize", () => {
       score: number | null;
       reviewer_comment: string | null;
       applicant_note: string | null;
-    }>(
-      env.DB,
-      "SELECT score, reviewer_comment, applicant_note FROM proposal_reviews WHERE id = ?",
-      [reviews[0].id],
-    );
+    }>(env.DB, "SELECT score, reviewer_comment, applicant_note FROM proposal_reviews WHERE id = ?", [reviews[0].id]);
     expect(clearedReviewRows).toEqual([
       {
         score: null,

--- a/tests/proposal-review.test.ts
+++ b/tests/proposal-review.test.ts
@@ -140,6 +140,51 @@ describe("proposal review and finalize", () => {
       reviewerComment: { from: "Good", to: "Excellent" },
       applicantNote: { from: null, to: "Ready for acceptance" },
     });
+
+    const clearResponse = await patchReview(
+      createContext(
+        env,
+        new Request(`https://app.test/api/v1/admin/proposals/${proposalId}/reviews/${reviews[0].id}`, {
+          method: "PATCH",
+          headers: {
+            "content-type": "application/json",
+            authorization: `Bearer ${admin1Token}`,
+          },
+          body: JSON.stringify({ score: null, reviewerComment: null, applicantNote: null }),
+        }),
+        { proposalId, reviewId: reviews[0].id },
+      ),
+    );
+
+    expect(clearResponse.status).toBe(200);
+
+    const clearedReviewRows = await queryAll<{
+      score: number | null;
+      reviewer_comment: string | null;
+      applicant_note: string | null;
+    }>(
+      env.DB,
+      "SELECT score, reviewer_comment, applicant_note FROM proposal_reviews WHERE id = ?",
+      [reviews[0].id],
+    );
+    expect(clearedReviewRows).toEqual([
+      {
+        score: null,
+        reviewer_comment: null,
+        applicant_note: null,
+      },
+    ]);
+
+    const clearedAuditRows = await queryAll<{ details_json: string }>(
+      env.DB,
+      "SELECT details_json FROM audit_log WHERE action = 'proposal_review_upserted' ORDER BY created_at ASC",
+    );
+    expect(clearedAuditRows).toHaveLength(3);
+    expect(JSON.parse(clearedAuditRows[2].details_json)).toMatchObject({
+      score: { from: 10, to: null },
+      reviewerComment: { from: "Excellent", to: null },
+      applicantNote: { from: "Ready for acceptance", to: null },
+    });
   });
 
   it("enforces minimum reviews before final decision", async () => {


### PR DESCRIPTION
This pull request introduces support for draft and submitted states for proposal reviews, allowing reviewers to save their work as drafts before submitting. The changes affect both backend and frontend logic, ensuring that only submitted reviews count towards quorum and review statistics. The UI has been updated to reflect the new workflow, providing clear feedback and actions for saving drafts and submitting reviews.

**Backend changes for review status:**

* Added `status` ("draft" or "submitted") and `submitted_at` fields to the `ProposalReview` and `ProposalReviewRecord` types, and updated database operations to handle these fields accordingly. [[1]](diffhunk://#diff-9ee7edf1ff3620885289058e099c4660b67a9e8a1710b90b8fde5c4c405f3aeaR166-R170) [[2]](diffhunk://#diff-fc0d55bbfc5bc5cd1d09525e8072600f2a75fbb6992f5b02a364853066a99f80R35-R39) [[3]](diffhunk://#diff-fc0d55bbfc5bc5cd1d09525e8072600f2a75fbb6992f5b02a364853066a99f80R656-R664) [[4]](diffhunk://#diff-fc0d55bbfc5bc5cd1d09525e8072600f2a75fbb6992f5b02a364853066a99f80R678-R702) [[5]](diffhunk://#diff-fc0d55bbfc5bc5cd1d09525e8072600f2a75fbb6992f5b02a364853066a99f80L705-R722) [[6]](diffhunk://#diff-fc0d55bbfc5bc5cd1d09525e8072600f2a75fbb6992f5b02a364853066a99f80R784) [[7]](diffhunk://#diff-fc0d55bbfc5bc5cd1d09525e8072600f2a75fbb6992f5b02a364853066a99f80R795-R817)
* Updated review creation and update logic to set `submitted_at` only when a review is submitted, and to default new reviews to "submitted" if no status is provided. [[1]](diffhunk://#diff-fc0d55bbfc5bc5cd1d09525e8072600f2a75fbb6992f5b02a364853066a99f80R656-R664) [[2]](diffhunk://#diff-fc0d55bbfc5bc5cd1d09525e8072600f2a75fbb6992f5b02a364853066a99f80R678-R702) [[3]](diffhunk://#diff-fc0d55bbfc5bc5cd1d09525e8072600f2a75fbb6992f5b02a364853066a99f80L705-R722) [[4]](diffhunk://#diff-fc0d55bbfc5bc5cd1d09525e8072600f2a75fbb6992f5b02a364853066a99f80R795-R817)
* Modified queries and logic for counting reviews and checking quorum to include only reviews with status "submitted". [[1]](diffhunk://#diff-fc0d55bbfc5bc5cd1d09525e8072600f2a75fbb6992f5b02a364853066a99f80L828-R850) [[2]](diffhunk://#diff-fc0d55bbfc5bc5cd1d09525e8072600f2a75fbb6992f5b02a364853066a99f80R940)

**Schema updates:**

* Updated `reviewUpsertSchema` and `reviewPatchSchema` to include the optional `status` field, defaulting to "submitted" where appropriate. [[1]](diffhunk://#diff-c0d49f9bc48997e6cd99cbf2c72994b92fa497fc5dd579cf19a5e0766b0e67eaR315) [[2]](diffhunk://#diff-c0d49f9bc48997e6cd99cbf2c72994b92fa497fc5dd579cf19a5e0766b0e67eaR329)

**Frontend/UI improvements:**

* Updated the review form to support saving as draft or submitting, with appropriate button labels and actions. The UI now distinguishes between editing a draft and a submitted review, and displays draft status badges where relevant. [[1]](diffhunk://#diff-6cc6992bac3ed03da8877f2d76575063c27283676111a4b756ef91f84de60654L581-R589) [[2]](diffhunk://#diff-6cc6992bac3ed03da8877f2d76575063c27283676111a4b756ef91f84de60654L597-R600) [[3]](diffhunk://#diff-6cc6992bac3ed03da8877f2d76575063c27283676111a4b756ef91f84de60654L839-R850) [[4]](diffhunk://#diff-6cc6992bac3ed03da8877f2d76575063c27283676111a4b756ef91f84de60654L899-R920) [[5]](diffhunk://#diff-6cc6992bac3ed03da8877f2d76575063c27283676111a4b756ef91f84de60654L546-R549) [[6]](diffhunk://#diff-6cc6992bac3ed03da8877f2d76575063c27283676111a4b756ef91f84de60654L696-R699) [[7]](diffhunk://#diff-6cc6992bac3ed03da8877f2d76575063c27283676111a4b756ef91f84de60654L814-R823) [[8]](diffhunk://#diff-6cc6992bac3ed03da8877f2d76575063c27283676111a4b756ef91f84de60654L946-R965) [[9]](diffhunk://#diff-6cc6992bac3ed03da8877f2d76575063c27283676111a4b756ef91f84de60654L1145-R1164) [[10]](diffhunk://#diff-6cc6992bac3ed03da8877f2d76575063c27283676111a4b756ef91f84de60654R413)
* All review counts and quorum checks now reflect only submitted reviews, ensuring accurate progress indicators and validation before finalizing decisions. [[1]](diffhunk://#diff-6cc6992bac3ed03da8877f2d76575063c27283676111a4b756ef91f84de60654L515-R518) [[2]](diffhunk://#diff-6cc6992bac3ed03da8877f2d76575063c27283676111a4b756ef91f84de60654L546-R549) [[3]](diffhunk://#diff-6cc6992bac3ed03da8877f2d76575063c27283676111a4b756ef91f84de60654L696-R699) [[4]](diffhunk://#diff-6cc6992bac3ed03da8877f2d76575063c27283676111a4b756ef91f84de60654L814-R823) [[5]](diffhunk://#diff-6cc6992bac3ed03da8877f2d76575063c27283676111a4b756ef91f84de60654L946-R965) [[6]](diffhunk://#diff-6cc6992bac3ed03da8877f2d76575063c27283676111a4b756ef91f84de60654L1145-R1164)