### PR TITLE
Improve admin proposal review dashboard

### DIFF
--- a/assets/scss/admin.scss
+++ b/assets/scss/admin.scss
@@ -823,6 +823,55 @@ $adm-danger: #dc3545;
   .adm-pre-wrap {
     white-space: pre-wrap;
   }
+  .adm-markdown {
+    line-height: 1.5;
+
+    > :last-child {
+      margin-bottom: 0;
+    }
+
+    p,
+    ul,
+    ol,
+    blockquote,
+    pre {
+      margin-bottom: 0.5rem;
+    }
+
+    h2,
+    h3,
+    h4 {
+      font-size: 0.95rem;
+      margin: 0.25rem 0 0.4rem;
+    }
+
+    blockquote {
+      border-left: 3px solid $adm-border;
+      color: $adm-muted;
+      padding-left: 0.75rem;
+    }
+
+    code {
+      background: #f8f9fa;
+      border: 1px solid $adm-border;
+      border-radius: 0.25rem;
+      padding: 0.05rem 0.25rem;
+    }
+
+    pre {
+      background: #f8f9fa;
+      border: 1px solid $adm-border;
+      border-radius: 0.375rem;
+      padding: 0.5rem;
+      white-space: pre-wrap;
+    }
+
+    pre code {
+      background: transparent;
+      border: 0;
+      padding: 0;
+    }
+  }
   .adm-cell-title {
     max-width: 260px;
   }

--- a/assets/shared/schemas/api.ts
+++ b/assets/shared/schemas/api.ts
@@ -77,6 +77,8 @@ export const adminEmailOutboxQuerySchema = z.object({
 
 export const adminEventProposalsQuerySchema = z.object({
   status: z.string().trim().optional(),
+  recommendation: z.enum(["accept", "reject", "needs-work"]).optional(),
+  sort: z.enum(["submitted_desc", "score_desc", "score_asc"]).optional(),
   search: z.string().trim().optional(),
   limit: z.coerce.number().int().min(1).max(200).optional(),
   offset: z.coerce.number().int().min(0).optional(),

--- a/assets/ts/admin/sections/events/detail/ProposalDetailPage.tsx
+++ b/assets/ts/admin/sections/events/detail/ProposalDetailPage.tsx
@@ -3,6 +3,7 @@ import { useHashLocation } from "wouter/use-hash-location";
 import { Badge } from "../../../../components/Badge";
 import { Spinner } from "../../../../components/Spinner";
 import { ErrorAlert } from "../../../../components/ErrorAlert";
+import { Markdown } from "../../../../components/Markdown";
 import { DataTable } from "../../../../components/Table";
 import { Tabs } from "../../../../components/Tabs";
 import { api } from "../../../api";
@@ -411,11 +412,12 @@ function ReviewCard({ review }: { review: ProposalReview }) {
           <span class="small text-muted">{reviewer}</span>
           <span class="small text-muted ms-auto">{fmt(review.updated_at)}</span>
         </div>
-        {review.reviewer_comment && <p class="small mb-1">{review.reviewer_comment}</p>}
+        {review.reviewer_comment && <Markdown markdown={review.reviewer_comment} className="small mb-1" />}
         {review.applicant_note && (
-          <p class="small text-muted mb-0 border-start border-warning border-2 ps-2 fst-italic">
-            Note to applicant: {review.applicant_note}
-          </p>
+          <div class="small text-muted mb-0 border-start border-warning border-2 ps-2">
+            <div class="fw-semibold fst-italic mb-1">Note to applicant</div>
+            <Markdown markdown={review.applicant_note} />
+          </div>
         )}
       </div>
     </div>

--- a/assets/ts/admin/sections/events/detail/Proposals.tsx
+++ b/assets/ts/admin/sections/events/detail/Proposals.tsx
@@ -21,23 +21,55 @@ import { Invites } from "./Invites";
 interface ProposalsResponse {
   proposals: ProposalSummary[];
   access: ProposalAccess;
-  pagination: { offset: number; limit: number; total: number; hasMore: boolean };
+  page?: { offset: number; limit: number; total: number; hasMore: boolean };
+  pagination?: { offset: number; limit: number; total: number; hasMore: boolean };
+}
+
+type RecommendationFilter = "" | "accept" | "needs-work" | "reject";
+type ProposalSort = "submitted_desc" | "score_desc" | "score_asc";
+
+function formatAverageScore(score: number | null): string {
+  if (score == null) return "—";
+  return score.toFixed(1).replace(/\.0$/, "");
+}
+
+function recommendationSummary(p: ProposalSummary) {
+  const entries = [
+    ["accept", "Accept", Number(p.recommendation_accept_count ?? 0)],
+    ["needs-work", "Needs work", Number(p.recommendation_needs_work_count ?? 0)],
+    ["reject", "Reject", Number(p.recommendation_reject_count ?? 0)],
+  ] as const;
+  const visible = entries.filter(([, , count]) => count > 0);
+  if (visible.length === 0) return <span class="text-muted small">—</span>;
+
+  return (
+    <div class="d-flex gap-1 flex-wrap">
+      {visible.map(([status, label, count]) => (
+        <Badge key={status} status={status} label={`${label} ${count}`} />
+      ))}
+    </div>
+  );
 }
 
 function ProposalsList({ slug }: { slug: string }) {
   const { offset, pageSize, resetPage, pagerProps } = usePageState();
   const [statusFilter, setStatusFilter] = useState("");
+  const [recommendationFilter, setRecommendationFilter] = useState<RecommendationFilter>("");
+  const [sort, setSort] = useState<ProposalSort>("submitted_desc");
   const [, navigate] = useHashLocation();
 
   const { data, loading, error, reload } = useData<ProposalsResponse>(() => {
     const params = new URLSearchParams({ limit: String(pageSize), offset: String(offset) });
     if (statusFilter) params.set("status", statusFilter);
+    if (recommendationFilter) params.set("recommendation", recommendationFilter);
+    if (sort !== "submitted_desc") params.set("sort", sort);
     return api<ProposalsResponse>(`/api/v1/admin/events/${slug}/proposals?${params}`);
-  }, [slug, statusFilter, offset, pageSize]);
+  }, [slug, statusFilter, recommendationFilter, sort, offset, pageSize]);
 
   const proposals = data?.proposals ?? [];
-  const total = data?.pagination?.total ?? 0;
-  const hasMore = data?.pagination?.hasMore ?? false;
+  const page = data?.pagination ?? data?.page;
+  const total = page?.total ?? 0;
+  const hasMore = page?.hasMore ?? false;
 
   return (
     <div>
@@ -59,6 +91,33 @@ function ProposalsList({ slug }: { slug: string }) {
           <option value="needs-work">Needs Work</option>
           <option value="withdrawn">Withdrawn</option>
         </select>
+        <label class="form-label mb-0 small fw-semibold">Recommendation</label>
+        <select
+          class="form-select form-select-sm adm-filter-select"
+          value={recommendationFilter}
+          onChange={(e) => {
+            setRecommendationFilter((e.target as HTMLSelectElement).value as RecommendationFilter);
+            resetPage();
+          }}
+        >
+          <option value="">All</option>
+          <option value="accept">Accept</option>
+          <option value="needs-work">Needs Work</option>
+          <option value="reject">Reject</option>
+        </select>
+        <label class="form-label mb-0 small fw-semibold">Sort</label>
+        <select
+          class="form-select form-select-sm adm-filter-select"
+          value={sort}
+          onChange={(e) => {
+            setSort((e.target as HTMLSelectElement).value as ProposalSort);
+            resetPage();
+          }}
+        >
+          <option value="submitted_desc">Submitted newest</option>
+          <option value="score_desc">Score high to low</option>
+          <option value="score_asc">Score low to high</option>
+        </select>
         <button class="btn btn-sm btn-outline-secondary ms-auto" onClick={() => void reload()}>
           ↺ Refresh
         </button>
@@ -71,7 +130,18 @@ function ProposalsList({ slug }: { slug: string }) {
       ) : (
         <>
           <Table
-            heads={["Title", "Proposer", "Type", "Status", "Decision", "Reviews", "Submitted", ""]}
+            heads={[
+              "Title",
+              "Proposer",
+              "Type",
+              "Status",
+              "Decision",
+              "Avg Score",
+              "Recommendations",
+              "Reviews",
+              "Submitted",
+              "",
+            ]}
             empty="No proposals found"
           >
             {proposals.length > 0 &&
@@ -104,6 +174,8 @@ function ProposalsList({ slug }: { slug: string }) {
                           <span class="text-muted small">—</span>
                         )}
                       </td>
+                      <td class="mono">{formatAverageScore(p.average_review_score)}</td>
+                      <td>{recommendationSummary(p)}</td>
                       <td class="mono">{p.review_count}</td>
                       <td class="mono small">{fmt(p.submitted_at)}</td>
                       <td>

--- a/assets/ts/admin/types.ts
+++ b/assets/ts/admin/types.ts
@@ -154,6 +154,10 @@ export interface ProposalSummary {
   proposer_first_name: string | null;
   proposer_last_name: string | null;
   review_count: number;
+  average_review_score: number | null;
+  recommendation_accept_count: number;
+  recommendation_needs_work_count: number;
+  recommendation_reject_count: number;
   decision_status: string | null;
   decision_note: string | null;
   decision_decided_at: string | null;

--- a/assets/ts/components/Markdown.tsx
+++ b/assets/ts/components/Markdown.tsx
@@ -1,0 +1,167 @@
+import { Fragment, type ComponentChildren } from "preact";
+
+type ListBlock = { type: "ul" | "ol"; items: string[] };
+type Block =
+  | { type: "paragraph"; text: string }
+  | { type: "heading"; level: 2 | 3 | 4; text: string }
+  | { type: "blockquote"; text: string }
+  | { type: "code"; text: string }
+  | ListBlock;
+
+function isSafeHref(href: string): boolean {
+  return /^(https?:|mailto:|\/(?!\/)|#)/i.test(href);
+}
+
+function renderInline(text: string): ComponentChildren[] {
+  const nodes: ComponentChildren[] = [];
+  const pattern = /(`([^`]+)`)|(\*\*([^*]+)\*\*)|(\*([^*]+)\*)|(\[([^\]]+)\]\(([^)\s]+)\))/g;
+  let last = 0;
+  let match: RegExpExecArray | null;
+
+  while ((match = pattern.exec(text))) {
+    if (match.index > last) nodes.push(text.slice(last, match.index));
+
+    if (match[2]) {
+      nodes.push(<code>{match[2]}</code>);
+    } else if (match[4]) {
+      nodes.push(<strong>{renderInline(match[4])}</strong>);
+    } else if (match[6]) {
+      nodes.push(<em>{renderInline(match[6])}</em>);
+    } else if (match[8] && match[9]) {
+      const href = match[9];
+      nodes.push(
+        isSafeHref(href) ? (
+          <a href={href} target={href.startsWith("http") ? "_blank" : undefined} rel="noopener noreferrer">
+            {renderInline(match[8])}
+          </a>
+        ) : (
+          match[8]
+        ),
+      );
+    }
+
+    last = pattern.lastIndex;
+  }
+
+  if (last < text.length) nodes.push(text.slice(last));
+  return nodes;
+}
+
+function parseMarkdown(markdown: string): Block[] {
+  const lines = markdown.replace(/\r\n?/g, "\n").split("\n");
+  const blocks: Block[] = [];
+  let i = 0;
+
+  while (i < lines.length) {
+    const line = lines[i];
+    if (!line.trim()) {
+      i++;
+      continue;
+    }
+
+    if (line.trim().startsWith("```")) {
+      const code: string[] = [];
+      i++;
+      while (i < lines.length && !lines[i].trim().startsWith("```")) {
+        code.push(lines[i]);
+        i++;
+      }
+      if (i < lines.length) i++;
+      blocks.push({ type: "code", text: code.join("\n") });
+      continue;
+    }
+
+    const heading = /^(#{1,4})\s+(.+)$/.exec(line);
+    if (heading) {
+      blocks.push({ type: "heading", level: Math.max(2, heading[1].length) as 2 | 3 | 4, text: heading[2] });
+      i++;
+      continue;
+    }
+
+    if (/^\s*>\s?/.test(line)) {
+      const quote: string[] = [];
+      while (i < lines.length && /^\s*>\s?/.test(lines[i])) {
+        quote.push(lines[i].replace(/^\s*>\s?/, ""));
+        i++;
+      }
+      blocks.push({ type: "blockquote", text: quote.join("\n") });
+      continue;
+    }
+
+    const unordered = /^\s*[-*]\s+(.+)$/.exec(line);
+    const ordered = /^\s*\d+[.)]\s+(.+)$/.exec(line);
+    if (unordered || ordered) {
+      const type: ListBlock["type"] = unordered ? "ul" : "ol";
+      const items: string[] = [];
+      while (i < lines.length) {
+        const item = type === "ul" ? /^\s*[-*]\s+(.+)$/.exec(lines[i]) : /^\s*\d+[.)]\s+(.+)$/.exec(lines[i]);
+        if (!item) break;
+        items.push(item[1]);
+        i++;
+      }
+      blocks.push({ type, items });
+      continue;
+    }
+
+    const paragraph: string[] = [line.trim()];
+    i++;
+    while (
+      i < lines.length &&
+      lines[i].trim() &&
+      !/^(#{1,4})\s+/.test(lines[i]) &&
+      !/^\s*([-*]|\d+[.)])\s+/.test(lines[i]) &&
+      !/^\s*>\s?/.test(lines[i]) &&
+      !lines[i].trim().startsWith("```")
+    ) {
+      paragraph.push(lines[i].trim());
+      i++;
+    }
+    blocks.push({ type: "paragraph", text: paragraph.join(" ") });
+  }
+
+  return blocks;
+}
+
+export function Markdown({ markdown, className }: { markdown: string; className?: string }) {
+  const blocks = parseMarkdown(markdown);
+
+  return (
+    <div class={`adm-markdown${className ? ` ${className}` : ""}`}>
+      {blocks.map((block, index) => {
+        switch (block.type) {
+          case "heading": {
+            const Heading = `h${block.level}` as "h2" | "h3" | "h4";
+            return <Heading key={index}>{renderInline(block.text)}</Heading>;
+          }
+          case "blockquote":
+            return <blockquote key={index}>{renderInline(block.text)}</blockquote>;
+          case "code":
+            return (
+              <pre key={index}>
+                <code>{block.text}</code>
+              </pre>
+            );
+          case "ul":
+            return (
+              <ul key={index}>
+                {block.items.map((item, itemIndex) => (
+                  <li key={itemIndex}>{renderInline(item)}</li>
+                ))}
+              </ul>
+            );
+          case "ol":
+            return (
+              <ol key={index}>
+                {block.items.map((item, itemIndex) => (
+                  <li key={itemIndex}>{renderInline(item)}</li>
+                ))}
+              </ol>
+            );
+          default:
+            return <p key={index}>{renderInline(block.text)}</p>;
+        }
+      })}
+      {blocks.length === 0 && <Fragment />}
+    </div>
+  );
+}

--- a/assets/ts/components/Markdown.tsx
+++ b/assets/ts/components/Markdown.tsx
@@ -9,7 +9,10 @@ type Block =
   | ListBlock;
 
 function isSafeHref(href: string): boolean {
-  return /^(https?:|mailto:|\/(?!\/)|#)/i.test(href);
+  if (/^[a-z0-9+.-]+:/i.test(href)) {
+    return /^(https?:|mailto:|tel:)/i.test(href);
+  }
+  return !href.startsWith("//");
 }
 
 function renderInline(text: string): ComponentChildren[] {
@@ -20,18 +23,19 @@ function renderInline(text: string): ComponentChildren[] {
 
   while ((match = pattern.exec(text))) {
     if (match.index > last) nodes.push(text.slice(last, match.index));
+    const key = `${match.index}-${pattern.lastIndex}`;
 
     if (match[2]) {
-      nodes.push(<code>{match[2]}</code>);
+      nodes.push(<code key={key}>{match[2]}</code>);
     } else if (match[4]) {
-      nodes.push(<strong>{renderInline(match[4])}</strong>);
+      nodes.push(<strong key={key}>{renderInline(match[4])}</strong>);
     } else if (match[6]) {
-      nodes.push(<em>{renderInline(match[6])}</em>);
+      nodes.push(<em key={key}>{renderInline(match[6])}</em>);
     } else if (match[8] && match[9]) {
       const href = match[9];
       nodes.push(
         isSafeHref(href) ? (
-          <a href={href} target={href.startsWith("http") ? "_blank" : undefined} rel="noopener noreferrer">
+          <a href={href} target={/^https?:/i.test(href) ? "_blank" : undefined} rel="noopener noreferrer" key={key}>
             {renderInline(match[8])}
           </a>
         ) : (
@@ -122,8 +126,8 @@ function parseMarkdown(markdown: string): Block[] {
   return blocks;
 }
 
-export function Markdown({ markdown, className }: { markdown: string; className?: string }) {
-  const blocks = parseMarkdown(markdown);
+export function Markdown({ markdown = "", className }: { markdown?: string | null; className?: string }) {
+  const blocks = parseMarkdown(markdown ?? "");
 
   return (
     <div class={`adm-markdown${className ? ` ${className}` : ""}`}>

--- a/functions/_lib/services/proposals.ts
+++ b/functions/_lib/services/proposals.ts
@@ -47,6 +47,10 @@ export interface ProposalListRecord extends ProposalRecord {
   proposer_first_name: string | null;
   proposer_last_name: string | null;
   review_count: number;
+  average_review_score?: number | null;
+  recommendation_accept_count?: number;
+  recommendation_needs_work_count?: number;
+  recommendation_reject_count?: number;
   decision_status: "accepted" | "rejected" | "needs-work" | null;
   decision_note: string | null;
   decision_decided_at: string | null;

--- a/functions/api/v1/admin/events/[eventSlug]/proposals.ts
+++ b/functions/api/v1/admin/events/[eventSlug]/proposals.ts
@@ -15,6 +15,8 @@ export async function onRequestGet(c: AdminContext): Promise<Response> {
 
   const url = new URL(c.req.raw.url);
   const status = url.searchParams.get("status")?.trim() ?? "";
+  const recommendation = url.searchParams.get("recommendation")?.trim() ?? "";
+  const sort = url.searchParams.get("sort")?.trim() ?? "submitted_desc";
   const search = url.searchParams.get("search")?.trim().toLowerCase() ?? "";
   const limit = Math.min(200, Math.max(1, parseInt(url.searchParams.get("limit") ?? "50", 10) || 50));
   const offset = Math.max(0, parseInt(url.searchParams.get("offset") ?? "0", 10) || 0);
@@ -27,6 +29,13 @@ export async function onRequestGet(c: AdminContext): Promise<Response> {
     params.push(status);
   }
 
+  if (recommendation) {
+    conditions.push(
+      "EXISTS (SELECT 1 FROM proposal_reviews pr_filter WHERE pr_filter.proposal_id = sp.id AND pr_filter.recommendation = ?)",
+    );
+    params.push(recommendation);
+  }
+
   if (search) {
     conditions.push(
       "(LOWER(sp.title) LIKE ? OR LOWER(COALESCE(u.first_name, '') || ' ' || COALESCE(u.last_name, '') || ' ' || u.email) LIKE ?)",
@@ -34,6 +43,13 @@ export async function onRequestGet(c: AdminContext): Promise<Response> {
     const pattern = `%${search}%`;
     params.push(pattern, pattern);
   }
+
+  const orderBy =
+    sort === "score_desc"
+      ? "rv.average_review_score IS NULL ASC, rv.average_review_score DESC, sp.submitted_at DESC"
+      : sort === "score_asc"
+        ? "rv.average_review_score IS NULL ASC, rv.average_review_score ASC, sp.submitted_at DESC"
+        : "sp.submitted_at DESC";
 
   const rows = await all<ProposalListRecord>(
     requestDb(c),
@@ -43,19 +59,29 @@ export async function onRequestGet(c: AdminContext): Promise<Response> {
        u.first_name AS proposer_first_name,
        u.last_name  AS proposer_last_name,
        COALESCE(rv.review_count, 0) AS review_count,
+       rv.average_review_score AS average_review_score,
+       COALESCE(rv.accept_count, 0) AS recommendation_accept_count,
+       COALESCE(rv.needs_work_count, 0) AS recommendation_needs_work_count,
+       COALESCE(rv.reject_count, 0) AS recommendation_reject_count,
        pd.final_status AS decision_status,
        pd.decision_note AS decision_note,
        pd.decided_at AS decision_decided_at
      FROM session_proposals sp
      JOIN users u ON u.id = sp.proposer_user_id
      LEFT JOIN (
-       SELECT proposal_id, COUNT(*) AS review_count
+       SELECT
+         proposal_id,
+         COUNT(*) AS review_count,
+         AVG(score) AS average_review_score,
+         SUM(CASE WHEN recommendation = 'accept' THEN 1 ELSE 0 END) AS accept_count,
+         SUM(CASE WHEN recommendation = 'needs-work' THEN 1 ELSE 0 END) AS needs_work_count,
+         SUM(CASE WHEN recommendation = 'reject' THEN 1 ELSE 0 END) AS reject_count
        FROM proposal_reviews
        GROUP BY proposal_id
      ) rv ON rv.proposal_id = sp.id
      LEFT JOIN proposal_decisions pd ON pd.proposal_id = sp.id
      WHERE ${conditions.join(" AND ")}
-     ORDER BY sp.submitted_at DESC
+     ORDER BY ${orderBy}
      LIMIT ? OFFSET ?`,
     [...params, limit + 1, offset],
   );
@@ -76,6 +102,12 @@ export async function onRequestGet(c: AdminContext): Promise<Response> {
     event: { id: event.id, slug: event.slug, name: event.name },
     permissions: access,
     proposals,
+    pagination: {
+      limit,
+      offset,
+      hasMore,
+      total,
+    },
     page: {
       limit,
       offset,

--- a/tests/admin-proposals-endpoints.test.ts
+++ b/tests/admin-proposals-endpoints.test.ts
@@ -174,14 +174,87 @@ describe("admin proposal endpoints", () => {
       proposals: Array<{
         proposer_email: string;
         review_count: number;
+        average_review_score: number | null;
+        recommendation_accept_count: number;
         decision_status: string | null;
       }>;
+      pagination: { total: number; hasMore: boolean };
     };
 
     expect(payload.proposals.length).toBe(1);
     expect(payload.proposals[0].proposer_email).toBe("speaker@pkic.org");
     expect(Number(payload.proposals[0].review_count)).toBe(1);
+    expect(Number(payload.proposals[0].average_review_score)).toBe(9);
+    expect(Number(payload.proposals[0].recommendation_accept_count)).toBe(1);
     expect(payload.proposals[0].decision_status).toBe("accepted");
+    expect(payload.pagination.total).toBe(1);
+  });
+
+  it("filters proposal list by recommendation and sorts by average score", async () => {
+    const { eventId } = await seedEventAndAdmin(env.DB);
+    const { adminId } = await seedProposalWithReviews(env.DB, eventId);
+    const secondProposalId = crypto.randomUUID();
+    const secondProposerId = crypto.randomUUID();
+
+    await env.DB.batch([
+      env.DB.prepare(`
+        INSERT INTO users (id, email, normalized_email, first_name, last_name, organization_name, job_title, data_json, created_at, updated_at)
+        VALUES ('${secondProposerId}', 'speaker-two@pkic.org', 'speaker-two@pkic.org', 'Speaker', 'Two', 'Org', 'Role', NULL, datetime('now'), datetime('now'))
+      `),
+      env.DB.prepare(`
+        INSERT INTO session_proposals (
+          id, event_id, proposer_user_id, status, proposal_type, title, abstract,
+          details_json, referral_code, manage_token_hash, submitted_at, updated_at, withdrawn_at
+        ) VALUES (
+          '${secondProposalId}', '${eventId}', '${secondProposerId}', 'submitted', 'talk', 'Lower Score Proposal',
+          'Another proposal abstract that is long enough to represent realistic content for testing.',
+          NULL, NULL, 'hash-two', datetime('now', '-1 minute'), datetime('now'), NULL
+        )
+      `),
+      env.DB.prepare(`
+        INSERT INTO proposal_reviews (
+          id, proposal_id, reviewer_user_id, recommendation, score,
+          reviewer_comment, applicant_note, created_at, updated_at
+        ) VALUES (
+          '${crypto.randomUUID()}', '${secondProposalId}', '${adminId}', 'reject', 3,
+          'Too narrow for this event', NULL, datetime('now'), datetime('now')
+        )
+      `),
+    ]);
+
+    const adminToken = await createAdminSession(env.DB, adminId, "token-admin-list-sort");
+    const scoreResponse = await getEventProposals(
+      createContext(
+        env,
+        new Request("https://app.test/api/v1/admin/events/pqc-2026/proposals?sort=score_asc", {
+          headers: { authorization: `Bearer ${adminToken}` },
+        }),
+        { eventSlug: "pqc-2026" },
+      ),
+    );
+    const scorePayload = (await scoreResponse.json()) as { proposals: Array<{ title: string }> };
+    expect(scorePayload.proposals.map((proposal) => proposal.title)).toEqual([
+      "Lower Score Proposal",
+      "Endpoint Proposal",
+    ]);
+
+    const filterResponse = await getEventProposals(
+      createContext(
+        env,
+        new Request("https://app.test/api/v1/admin/events/pqc-2026/proposals?recommendation=reject", {
+          headers: { authorization: `Bearer ${adminToken}` },
+        }),
+        { eventSlug: "pqc-2026" },
+      ),
+    );
+    const filterPayload = (await filterResponse.json()) as {
+      proposals: Array<{ title: string; recommendation_reject_count: number }>;
+      pagination: { total: number };
+    };
+    expect(filterPayload.proposals).toHaveLength(1);
+    expect(filterPayload.proposals[0].title).toBe("Lower Score Proposal");
+    expect(Number(filterPayload.proposals[0].recommendation_reject_count)).toBe(1);
+    expect(filterPayload.pagination.total).toBe(1);
   });
 
   it("returns proposal detail with parsed answers and active form fields", async () => {


### PR DESCRIPTION
## Summary
- fix proposal dashboard pagination by aligning the UI with the API page metadata
- show average review scores and recommendation counts on proposals
- add score sorting, recommendation filtering, and safe Markdown rendering for review notes

## Tests
- pnpm check
- pnpm test:e2e