### PR TITLE
Add profile for Ministry of Home Affairs, Immigration, Safety and Security

### DIFF
--- a/data/members/mhaiss.yaml
+++ b/data/members/mhaiss.yaml
@@ -5,6 +5,7 @@ website: https://mhaiss.gov.na
 # Business domains for email
 organizationDomains:
   - mha.gov.na
+  - mhaiss.gov.na
 # Short description, longer content can be placed in `content/members/`
 description: Ministry of Home Affairs, Immigration, Safety and Security
 
@@ -22,29 +23,29 @@ sponsor:
 
 # Blog posts
 blog:
-  url: 
-  feed: 
+  url:
+  feed:
   language: en_US
 
 # Press Releases
 press:
   url: https://mhaiss.gov.na/media
-  feed: 
+  feed:
   language: en_US
 
 # Careers
 careers:
-  url: 
-  feed: 
+  url:
+  feed:
   language: en_US
 
 # Social media
 social:
   x: https://twitter.com/MHAINamibia
   facebook: https://www.facebook.com/MHAINamibia
-  instagram: 
-  linkedin: 
-  youtube: 
+  instagram:
+  linkedin:
+  youtube:
 
 # Here you can list those who represent or have represented the member.
 #
@@ -52,11 +53,11 @@ social:
 # to keep the attribution a from/till data range can be included.
 representatives:
   - name: Daniel Nelumbu
-    role: Deputy Director: IT
+    role: "Deputy Director: IT"
     social:
       x:
       linkedin: https://www.linkedin.com/in/daniel-n-nelumbu-576354144/
-    description: Daniel is the Deputy Director: IT at Ministry of Home Affairs, Immigration, Safety and Security and represents the organization at the PKI Consortium.
+    description: "Daniel is the Deputy Director: IT at Ministry of Home Affairs, Immigration, Safety and Security and represents the organization at the PKI Consortium."
 
 # Long-form content (markdown)
 content: |

--- a/data/members/mhaiss.yaml
+++ b/data/members/mhaiss.yaml
@@ -1,0 +1,62 @@
+id: mhaiss
+name: Ministry of Home Affairs, Immigration, Safety and Security
+slogan:
+website: https://mhaiss.gov.na
+# Business domains for email
+organizationDomains:
+  - mha.gov.na
+# Short description, longer content can be placed in `content/members/`
+description: Ministry of Home Affairs, Immigration, Safety and Security
+
+# membership
+memberSince: 2026-07-07
+memberType: A
+workingGroups:
+  - PKIMM
+  - PQC
+  - TCWG
+
+# sponsor
+sponsor:
+  level:
+
+# Blog posts
+blog:
+  url: 
+  feed: 
+  language: en_US
+
+# Press Releases
+press:
+  url: https://mhaiss.gov.na/media
+  feed: 
+  language: en_US
+
+# Careers
+careers:
+  url: 
+  feed: 
+  language: en_US
+
+# Social media
+social:
+  x: https://twitter.com/MHAINamibia
+  facebook: https://www.facebook.com/MHAINamibia
+  instagram: 
+  linkedin: 
+  youtube: 
+
+# Here you can list those who represent or have represented the member.
+#
+# Those who no longer represent an organization might have written blog posts,
+# to keep the attribution a from/till data range can be included.
+representatives:
+  - name: Daniel Nelumbu
+    role: Deputy Director: IT
+    social:
+      x:
+      linkedin: https://www.linkedin.com/in/daniel-n-nelumbu-576354144/
+    description: Daniel is the Deputy Director: IT at Ministry of Home Affairs, Immigration, Safety and Security and represents the organization at the PKI Consortium.
+
+# Long-form content (markdown)
+content: |


### PR DESCRIPTION
Automatically generated pull request to add profile for Ministry of Home Affairs, Immigration, Safety and Security according to application pkic/members#805.

This closes pkic/members#805

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new member profile for the Ministry of Home Affairs, Immigration, Safety and Security.
  * Included organization details, website, contact domains, membership information, working groups, and social media links.
  * Added representative information for Daniel Nelumbu, including role and social profiles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->