### PR TITLE
Add profile for CNA

### DIFF
--- a/data/members/cna.yaml
+++ b/data/members/cna.yaml
@@ -1,0 +1,64 @@
+id: cna
+name: CNA
+slogan:
+website: https://www.cna.com/
+# Business domains for email
+organizationDomains:
+  - cna.com
+# Short description, longer content can be placed in `content/members/`
+description: 
+
+# membership
+memberSince: 2026-08-09
+memberType: H8
+workingGroups:
+  - CBOM
+  - CM
+  - PKIMM
+  - PQC
+  - TCWG
+
+# sponsor
+sponsor:
+  level:
+
+# Blog posts
+blog:
+  url: 
+  feed: 
+  language: en_US
+
+# Press Releases
+press:
+  url: 
+  feed: 
+  language: en_US
+
+# Careers
+careers:
+  url: 
+  feed: 
+  language: en_US
+
+# Social media
+social:
+  x: 
+  facebook: 
+  instagram: 
+  linkedin: 
+  youtube: 
+
+# Here you can list those who represent or have represented the member.
+#
+# Those who no longer represent an organization might have written blog posts,
+# to keep the attribution a from/till data range can be included.
+representatives:
+  - name: Chante Gillyard
+    role: Director, Data Security
+    social:
+      x:
+      linkedin: https://www.linkedin.com/in/chante-r-gillyard-msit-934539160/
+    description: Chante is the Director, Data Security at CNA and represents the organization at the PKI Consortium.
+
+# Long-form content (markdown)
+content: |


### PR DESCRIPTION
Automatically generated pull request to add profile for CNA according to application pkic/members#841.

This closes pkic/members#841

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a CNA member profile with organization details, website, domain, membership information, and working group participation.
  * Added a representative contact entry.
  * Included placeholders for sponsorship and communication channel information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->