### PR TITLE
Add profile for Comcast

### DIFF
--- a/data/members/comcast.yaml
+++ b/data/members/comcast.yaml
@@ -1,0 +1,63 @@
+id: comcast
+name: Comcast
+slogan:
+website: https://corporate.comcast.com/
+# Business domains for email
+organizationDomains:
+  - comcast.com
+# Short description, longer content can be placed in `content/members/`
+description: 
+
+# membership
+memberSince: 2026-08-09
+memberType: H3
+workingGroups:
+  - CBOM
+  - CM
+  - PKIMM
+  - PQC
+
+# sponsor
+sponsor:
+  level:
+
+# Blog posts
+blog:
+  url: 
+  feed: 
+  language: en_US
+
+# Press Releases
+press:
+  url: 
+  feed: 
+  language: en_US
+
+# Careers
+careers:
+  url: 
+  feed: 
+  language: en_US
+
+# Social media
+social:
+  x: 
+  facebook: 
+  instagram: 
+  linkedin: 
+  youtube: 
+
+# Here you can list those who represent or have represented the member.
+#
+# Those who no longer represent an organization might have written blog posts,
+# to keep the attribution a from/till data range can be included.
+representatives:
+  - name: Bahman Rashidi
+    role: Sr. Director, Cybersecurity & Privacy Research Engineering
+    social:
+      x:
+      linkedin: https://www.linkedin.com/in/bahman-rashidi/
+    description: Bahman is the Sr. Director, Cybersecurity & Privacy Research Engineering at Comcast and represents the organization at the PKI Consortium.
+
+# Long-form content (markdown)
+content: |


### PR DESCRIPTION
Automatically generated pull request to add profile for Comcast according to application pkic/members#825.

This closes pkic/members#825

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Comcast member information, including organization details, membership status, participation, contact domain, and representative information.
  * Added placeholders for social links, sponsors, and content channels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->