### PR TITLE
Add profile for EUConfiance

### DIFF
--- a/data/members/euconfiance.yaml
+++ b/data/members/euconfiance.yaml
@@ -1,0 +1,64 @@
+id: euconfiance
+name: EUConfiance
+slogan:
+website: https://euconfiance.com
+# Business domains for email
+organizationDomains:
+  - euconfiance.com
+# Short description, longer content can be placed in `content/members/`
+description: 
+
+# membership
+memberSince: 2026-08-09
+memberType: H2
+workingGroups:
+  - CBOM
+  - CM
+  - PKIMM
+  - PQC
+  - TCWG
+
+# sponsor
+sponsor:
+  level:
+
+# Blog posts
+blog:
+  url: 
+  feed: 
+  language: en_US
+
+# Press Releases
+press:
+  url: 
+  feed: 
+  language: en_US
+
+# Careers
+careers:
+  url: 
+  feed: 
+  language: en_US
+
+# Social media
+social:
+  x: 
+  facebook: 
+  instagram: 
+  linkedin: 
+  youtube: 
+
+# Here you can list those who represent or have represented the member.
+#
+# Those who no longer represent an organization might have written blog posts,
+# to keep the attribution a from/till data range can be included.
+representatives:
+  - name: Gabriel CALIN
+    role: PKI Security Architect
+    social:
+      x:
+      linkedin: https://www.linkedin.com/in/gabriel-calin-9975aa235/
+    description: Gabriel is the PKI Security Architect at EUConfiance and represents the organization at the PKI Consortium.
+
+# Long-form content (markdown)
+content: |


### PR DESCRIPTION
Automatically generated pull request to add profile for EUConfiance according to application pkic/members#847.

This closes pkic/members#847

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the EUConfiance member profile with organization details, membership information, working groups, and representative contact.
  * Added configuration for the member’s long-form content.
  * Added placeholders for blogs, press, careers, and social media sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->