### PR TITLE
Add profile for enQase

### DIFF
--- a/data/members/enqase.yaml
+++ b/data/members/enqase.yaml
@@ -1,0 +1,60 @@
+id: enqase
+name: enQase
+slogan:
+website: https://www.enqase.com
+# Business domains for email
+organizationDomains:
+  - enqase.com
+# Short description, longer content can be placed in `content/members/`
+description: Every transaction, identity, and record today relies on encryption. Quantum computing will be able to break it - putting trillions in enterprise value at risk.
+
+# membership
+memberSince: 2026-08-09
+memberType: H2
+workingGroups:
+  - PQC
+
+# sponsor
+sponsor:
+  level:
+
+# Blog posts
+blog:
+  url: https://www.enqase.com/resources/articles
+  feed: 
+  language: en_US
+
+# Press Releases
+press:
+  url: 
+  feed: 
+  language: en_US
+
+# Careers
+careers:
+  url: 
+  feed: 
+  language: en_US
+
+# Social media
+social:
+  x: 
+  facebook: 
+  instagram: 
+  linkedin: https://www.linkedin.com/company/enqase
+  youtube: 
+
+# Here you can list those who represent or have represented the member.
+#
+# Those who no longer represent an organization might have written blog posts,
+# to keep the attribution a from/till data range can be included.
+representatives:
+  - name: Raj Patil
+    role: CEO
+    social:
+      x:
+      linkedin: https://www.linkedin.com/in/rajeshpatil/
+    description: Raj is the CEO at enQase and represents the organization at the PKI Consortium.
+
+# Long-form content (markdown)
+content: |


### PR DESCRIPTION
Automatically generated pull request to add profile for enQase according to application pkic/members#830.

This closes pkic/members#830

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an enQase member profile with organization details and quantum-security information.
  * Included H2 membership and PQC working-group participation details.
  * Added resource, social, and CEO representative links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->