### PR TITLE
Fix campaign preview query performance

### DIFF
--- a/functions/_lib/services/admin-email-campaign.ts
+++ b/functions/_lib/services/admin-email-campaign.ts
@@ -150,7 +150,7 @@ export async function listCampaignRecipients(
           ...dayWaitlistFilterParams(dayWaitlistStatus),
         ],
       );
-      return buildAttendeeCampaignRecipients(db, rows, form?.fields);
+      return buildAttendeeCampaignRecipients(db, event.id, rows, form?.fields);
     }
 
     const rows = await all<AttendeeCampaignRow>(
@@ -176,7 +176,7 @@ export async function listCampaignRecipients(
       ],
     );
 
-    return buildAttendeeCampaignRecipients(db, rows, form?.fields);
+    return buildAttendeeCampaignRecipients(db, event.id, rows, form?.fields);
   }
 
   if (filter.dayDate) {
@@ -241,44 +241,32 @@ function escapeRegex(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
-function chunkIds(ids: string[], size = 400): string[][] {
-  const chunks: string[][] = [];
-  for (let i = 0; i < ids.length; i += size) {
-    chunks.push(ids.slice(i, i + size));
-  }
-  return chunks;
-}
-
 async function listAttendeeDayAttendanceByRegistration(
   db: DatabaseLike,
-  registrationIds: string[],
+  eventId: string,
 ): Promise<Map<string, Array<{ dayDate: string; attendanceType: string; label: string | null }>>> {
   const byRegistration = new Map<string, Array<{ dayDate: string; attendanceType: string; label: string | null }>>();
-  if (registrationIds.length === 0) return byRegistration;
-
-  for (const chunk of chunkIds(registrationIds)) {
-    const placeholders = chunk.map(() => "?").join(", ");
-    const rows = await all<AttendeeDayAttendanceRow>(
-      db,
-      `SELECT rda.registration_id,
-              ed.day_date AS dayDate,
-              rda.attendance_type AS attendanceType,
-              ed.label AS label
-       FROM registration_day_attendance rda
-       JOIN event_days ed ON ed.id = rda.event_day_id
-       WHERE rda.registration_id IN (${placeholders})
-       ORDER BY rda.registration_id ASC, ed.sort_order ASC, ed.day_date ASC`,
-      chunk,
-    );
-    for (const row of rows) {
-      const entries = byRegistration.get(row.registration_id) ?? [];
-      entries.push({
-        dayDate: row.dayDate,
-        attendanceType: row.attendanceType,
-        label: row.label,
-      });
-      byRegistration.set(row.registration_id, entries);
-    }
+  const rows = await all<AttendeeDayAttendanceRow>(
+    db,
+    `SELECT rda.registration_id,
+            ed.day_date AS dayDate,
+            rda.attendance_type AS attendanceType,
+            ed.label AS label
+     FROM registration_day_attendance rda
+     JOIN registrations r ON r.id = rda.registration_id
+     JOIN event_days ed ON ed.id = rda.event_day_id
+     WHERE r.event_id = ?
+     ORDER BY rda.registration_id ASC, ed.sort_order ASC, ed.day_date ASC`,
+    [eventId],
+  );
+  for (const row of rows) {
+    const entries = byRegistration.get(row.registration_id) ?? [];
+    entries.push({
+      dayDate: row.dayDate,
+      attendanceType: row.attendanceType,
+      label: row.label,
+    });
+    byRegistration.set(row.registration_id, entries);
   }
 
   return byRegistration;
@@ -286,33 +274,28 @@ async function listAttendeeDayAttendanceByRegistration(
 
 async function listAttendeeDayWaitlistByRegistration(
   db: DatabaseLike,
-  registrationIds: string[],
+  eventId: string,
 ): Promise<Map<string, Array<{ dayDate: string; status: string }>>> {
   const byRegistration = new Map<string, Array<{ dayDate: string; status: string }>>();
-  if (registrationIds.length === 0) return byRegistration;
-
-  for (const chunk of chunkIds(registrationIds)) {
-    const placeholders = chunk.map(() => "?").join(", ");
-    const rows = await all<AttendeeDayWaitlistRow>(
-      db,
-      `SELECT w.registration_id,
-              ed.day_date AS dayDate,
-              w.status AS status
-       FROM event_day_waitlist_entries w
-       JOIN event_days ed ON ed.id = w.event_day_id
-       WHERE w.registration_id IN (${placeholders})
-         AND w.status IN ('waiting', 'offered', 'accepted')
-       ORDER BY w.registration_id ASC, ed.sort_order ASC, ed.day_date ASC`,
-      chunk,
-    );
-    for (const row of rows) {
-      const entries = byRegistration.get(row.registration_id) ?? [];
-      entries.push({
-        dayDate: row.dayDate,
-        status: row.status,
-      });
-      byRegistration.set(row.registration_id, entries);
-    }
+  const rows = await all<AttendeeDayWaitlistRow>(
+    db,
+    `SELECT w.registration_id,
+            ed.day_date AS dayDate,
+            w.status AS status
+     FROM event_day_waitlist_entries w
+     JOIN event_days ed ON ed.id = w.event_day_id
+     WHERE w.event_id = ?
+       AND w.status IN ('waiting', 'offered', 'accepted')
+     ORDER BY w.registration_id ASC, ed.sort_order ASC, ed.day_date ASC`,
+    [eventId],
+  );
+  for (const row of rows) {
+    const entries = byRegistration.get(row.registration_id) ?? [];
+    entries.push({
+      dayDate: row.dayDate,
+      status: row.status,
+    });
+    byRegistration.set(row.registration_id, entries);
   }
 
   return byRegistration;
@@ -320,13 +303,13 @@ async function listAttendeeDayWaitlistByRegistration(
 
 async function buildAttendeeCampaignRecipients(
   db: DatabaseLike,
+  eventId: string,
   rows: AttendeeCampaignRow[],
   formFields: FormFieldDefinition[] | undefined,
 ): Promise<CampaignRecipient[]> {
-  const registrationIds = Array.from(new Set(rows.map((row) => row.registration_id)));
   const [dayAttendanceByRegistration, dayWaitlistByRegistration] = await Promise.all([
-    listAttendeeDayAttendanceByRegistration(db, registrationIds),
-    listAttendeeDayWaitlistByRegistration(db, registrationIds),
+    listAttendeeDayAttendanceByRegistration(db, eventId),
+    listAttendeeDayWaitlistByRegistration(db, eventId),
   ]);
 
   return rows.map((row) => ({

--- a/tests/admin-email-campaign.test.ts
+++ b/tests/admin-email-campaign.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import { env } from "cloudflare:workers";
+import { getEventBySlug } from "../functions/_lib/services/events";
+import { listCampaignRecipients } from "../functions/_lib/services/admin-email-campaign";
+import { resetDb } from "./helpers/reset-db";
+import { seedEventAndAdmin } from "./helpers/context";
+
+describe("admin email campaign recipients", () => {
+  beforeEach(async () => {
+    await resetDb();
+  });
+
+  it("loads attendee details for a large event without per-recipient query batches", async () => {
+    const { eventId } = await seedEventAndAdmin(env.DB);
+    const users = Array.from({ length: 101 }, (_, index) => ({
+      id: `campaign-user-${index}`,
+      email: `campaign-user-${index}@example.test`,
+      manageTokenHash: `campaign-manage-token-${index}`,
+      registrationId: `campaign-registration-${index}`,
+    }));
+
+    await env.DB.batch(
+      users.map((user) =>
+        env.DB.prepare(
+          `INSERT INTO users (id, email, normalized_email, first_name, last_name, created_at, updated_at)
+             VALUES (?, ?, ?, ?, ?, datetime('now'), datetime('now'))`,
+        ).bind(user.id, user.email, user.email, "Campaign", `User ${user.id.split("-").pop()}`),
+      ),
+    );
+    await env.DB.batch(
+      users.map((user) =>
+        env.DB.prepare(
+          `INSERT INTO registrations (
+               id, event_id, user_id, status, attendance_type, source_type,
+               manage_token_hash, created_at, updated_at
+             ) VALUES (?, ?, ?, 'registered', 'virtual', 'direct', ?, datetime('now'), datetime('now'))`,
+        ).bind(user.registrationId, eventId, user.id, user.manageTokenHash),
+      ),
+    );
+
+    const event = await getEventBySlug(env.DB, "pqc-2026");
+    const recipients = await listCampaignRecipients(env.DB, event, "https://app.test", {
+      audience: "attendees",
+      attendeeStatus: "registered",
+      dayWaitlistStatus: "all",
+    });
+
+    expect(recipients).toHaveLength(users.length);
+    expect(recipients[0].templateData.dayWaitlist).toEqual([]);
+  });
+});

--- a/tests/admin-email-campaign.test.ts
+++ b/tests/admin-email-campaign.test.ts
@@ -4,6 +4,49 @@ import { getEventBySlug } from "../functions/_lib/services/events";
 import { listCampaignRecipients } from "../functions/_lib/services/admin-email-campaign";
 import { resetDb } from "./helpers/reset-db";
 import { seedEventAndAdmin } from "./helpers/context";
+import type { DatabaseLike, StatementLike } from "../functions/_lib/types";
+
+function countingDatabase(db: DatabaseLike, counts: { dayAttendance: number; dayWaitlist: number }): DatabaseLike {
+  function wrapStatement(statement: StatementLike, query: string): StatementLike {
+    const normalizedQuery = query.toLowerCase();
+    const queryType = normalizedQuery.includes("select rda.registration_id")
+      ? "dayAttendance"
+      : normalizedQuery.includes("select w.registration_id")
+        ? "dayWaitlist"
+        : null;
+
+    function countExecution(): void {
+      if (queryType) counts[queryType] += 1;
+    }
+
+    return {
+      bind(...values: unknown[]) {
+        return wrapStatement(statement.bind(...values), query);
+      },
+      async all<T>() {
+        countExecution();
+        return statement.all<T>();
+      },
+      async first<T>(columnName?: string) {
+        countExecution();
+        return statement.first<T>(columnName);
+      },
+      async run<T>() {
+        countExecution();
+        return statement.run<T>();
+      },
+    };
+  }
+
+  return {
+    prepare(query: string) {
+      return wrapStatement(db.prepare(query), query);
+    },
+    batch(statements) {
+      return db.batch(statements);
+    },
+  };
+}
 
 describe("admin email campaign recipients", () => {
   beforeEach(async () => {
@@ -39,13 +82,21 @@ describe("admin email campaign recipients", () => {
     );
 
     const event = await getEventBySlug(env.DB, "pqc-2026");
-    const recipients = await listCampaignRecipients(env.DB, event, "https://app.test", {
-      audience: "attendees",
-      attendeeStatus: "registered",
-      dayWaitlistStatus: "all",
-    });
+    const enrichmentQueryCounts = { dayAttendance: 0, dayWaitlist: 0 };
+    const recipients = await listCampaignRecipients(
+      countingDatabase(env.DB, enrichmentQueryCounts),
+      event,
+      "https://app.test",
+      {
+        audience: "attendees",
+        attendeeStatus: "registered",
+        dayWaitlistStatus: "all",
+      },
+    );
 
     expect(recipients).toHaveLength(users.length);
     expect(recipients[0].templateData.dayWaitlist).toEqual([]);
+    expect(enrichmentQueryCounts.dayAttendance).toBe(1);
+    expect(enrichmentQueryCounts.dayWaitlist).toBe(1);
   });
 });

--- a/tests/admin-email-campaign.test.ts
+++ b/tests/admin-email-campaign.test.ts
@@ -60,6 +60,7 @@ describe("admin email campaign recipients", () => {
       email: `campaign-user-${index}@example.test`,
       manageTokenHash: `campaign-manage-token-${index}`,
       registrationId: `campaign-registration-${index}`,
+      attendanceType: index === 100 ? "in_person" : "virtual",
     }));
 
     await env.DB.batch(
@@ -76,10 +77,30 @@ describe("admin email campaign recipients", () => {
           `INSERT INTO registrations (
                id, event_id, user_id, status, attendance_type, source_type,
                manage_token_hash, created_at, updated_at
-             ) VALUES (?, ?, ?, 'registered', 'virtual', 'direct', ?, datetime('now'), datetime('now'))`,
-        ).bind(user.registrationId, eventId, user.id, user.manageTokenHash),
+             ) VALUES (?, ?, ?, 'registered', ?, 'direct', ?, datetime('now'), datetime('now'))`,
+        ).bind(user.registrationId, eventId, user.id, user.attendanceType, user.manageTokenHash),
       ),
     );
+
+    const enrichedUser = users[100];
+    if (!enrichedUser) throw new Error("Expected the 101st campaign user to exist");
+    await env.DB.batch([
+      env.DB.prepare(
+        `INSERT INTO event_days (id, event_id, day_date, label, sort_order, created_at, updated_at)
+           VALUES (?, ?, ?, ?, ?, datetime('now'), datetime('now'))`,
+      ).bind("campaign-day-101", eventId, "2026-12-02", "Day 2", 10),
+      env.DB.prepare(
+        `INSERT INTO registration_day_attendance (
+             id, registration_id, event_day_id, attendance_type, created_at, updated_at
+           ) VALUES (?, ?, ?, ?, datetime('now'), datetime('now'))`,
+      ).bind("campaign-attendance-101", enrichedUser.registrationId, "campaign-day-101", "in_person"),
+      env.DB.prepare(
+        `INSERT INTO event_day_waitlist_entries (
+             id, event_id, event_day_id, registration_id, user_id, priority_lane,
+             status, position, created_at, updated_at
+           ) VALUES (?, ?, ?, ?, ?, 'general', 'waiting', ?, datetime('now'), datetime('now'))`,
+      ).bind("campaign-waitlist-101", eventId, "campaign-day-101", enrichedUser.registrationId, enrichedUser.id, 1),
+    ]);
 
     const event = await getEventBySlug(env.DB, "pqc-2026");
     const enrichmentQueryCounts = { dayAttendance: 0, dayWaitlist: 0 };
@@ -96,6 +117,18 @@ describe("admin email campaign recipients", () => {
 
     expect(recipients).toHaveLength(users.length);
     expect(recipients[0].templateData.dayWaitlist).toEqual([]);
+    const enrichedRecipient = recipients.find((recipient) => recipient.email === enrichedUser.email);
+    expect(enrichedRecipient?.templateData.dayAttendance).toEqual([
+      {
+        dayLabel: "Day 2",
+        attendanceLabel: "In person",
+        statusLabel: "Waitlisted for in-person attendance",
+        waitlistStatus: "waiting",
+        isWaitlisted: true,
+        isWaitlistOffer: false,
+      },
+    ]);
+    expect(enrichedRecipient?.templateData.dayWaitlist).toEqual([{ dayDate: "2026-12-02", status: "waiting" }]);
     expect(enrichmentQueryCounts.dayAttendance).toBe(1);
     expect(enrichmentQueryCounts.dayWaitlist).toBe(1);
   });


### PR DESCRIPTION
## Summary

- Replace per-100-registration enrichment batches with two event-scoped D1 queries.
- Preserve recipient-specific attendance and waitlist template data.
- Add a regression test covering a campaign with more than 100 attendees.

## Root cause

D1 limits bound parameters per statement. The previous enrichment path used registration-ID batches that exceeded the limit for large events, while reducing the batch size caused many extra queries and slow previews.

## Validation

- `pnpm check`
- 55 backend test files passed, 510 tests passed, 1 skipped
- 5 frontend test files passed, 17 tests passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved admin email campaign recipient selection for event attendees.
  * Ensured attendance and waitlist information is consistently included across larger recipient lists.
  * Improved enrichment accuracy by scoping attendee information to the selected event.
  * Improved campaign recipient loading for events with more than 100 registered attendees.

* **Tests**
  * Added coverage confirming campaigns return complete attendee details, including attendance and waitlist data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->