### PR TITLE
Add profile for CryptiQ Security

### DIFF
--- a/data/members/cryptiqsecurity.yaml
+++ b/data/members/cryptiqsecurity.yaml
@@ -1,0 +1,62 @@
+id: cryptiqsecurity
+name: CryptiQ Security
+slogan:
+website: https://cryptiqsecurity.com/
+# Business domains for email
+organizationDomains:
+  - cryptiqsecurity.com
+# Short description, longer content can be placed in `content/members/`
+description: CryptiQ finds the vulnerable encryption across your company and migrates it to quantum-safe NIST standards (ML-KEM, ML-DSA, SLH-DSA), with your team approving every change.
+
+# membership
+memberSince: 2026-08-12
+memberType: F
+workingGroups:
+  - CBOM
+  - PKIMM
+  - PQC
+
+# sponsor
+sponsor:
+  level:
+
+# Blog posts
+blog:
+  url: 
+  feed: 
+  language: en_US
+
+# Press Releases
+press:
+  url: 
+  feed: 
+  language: en_US
+
+# Careers
+careers:
+  url: 
+  feed: 
+  language: en_US
+
+# Social media
+social:
+  x: 
+  facebook: 
+  instagram: 
+  linkedin: https://www.linkedin.com/company/cryp-iq/
+  youtube: 
+
+# Here you can list those who represent or have represented the member.
+#
+# Those who no longer represent an organization might have written blog posts,
+# to keep the attribution a from/till data range can be included.
+representatives:
+  - name: Pranav Srinivasan
+    role: Founder
+    social:
+      x:
+      linkedin: https://www.linkedin.com/in/pranav-srinivasan-71378b261/
+    description: Pranav is the Founder at CryptiQ Security and represents the organization at the PKI Consortium.
+
+# Long-form content (markdown)
+content: |


### PR DESCRIPTION
Automatically generated pull request to add profile for CryptiQ Security according to application pkic/members#851.

This closes pkic/members#851

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CryptiQ Security to the member directory with organization details, quantum-safe cryptography information, membership metadata, working groups, social links, and representative details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->